### PR TITLE
feat: expose GET /entities/status/:id endpoint to public

### DIFF
--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -12,20 +12,21 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): DbComponent 
         registries
       WHERE 
         deployer = ${owner.toLocaleLowerCase()}
+      ORDER BY timestamp DESC
     `
 
     const result = await pg.query<Registry.DbEntity>(query)
     return result.rows
   }
 
-  async function getRegistriesByPointers(pointers: string[]): Promise<Registry.DbEntity[]> {
+  async function getSortedRegistriesByPointers(pointers: string[]): Promise<Registry.DbEntity[]> {
     const query = SQL`
       SELECT 
         id, type, timestamp, deployer, pointers, content, metadata, status, bundles
       FROM 
         registries
       WHERE 
-        pointers && ${pointers}::varchar(255)[] AND (status = ${Registry.Status.COMPLETE}::text OR status = ${Registry.Status.FALLBACK}::text)
+        pointers && ${pointers}::varchar(255)[]
       ORDER BY timestamp DESC
     `
 
@@ -273,7 +274,7 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): DbComponent 
     updateRegistriesStatus,
     upsertRegistryBundle,
     getSortedRegistriesByOwner,
-    getRegistriesByPointers,
+    getSortedRegistriesByPointers,
     getRegistryById,
     getRelatedRegistries,
     deleteRegistries,

--- a/src/controllers/handlers/get-active-entities.ts
+++ b/src/controllers/handlers/get-active-entities.ts
@@ -18,7 +18,7 @@ export async function getActiveEntityHandler(context: HandlerContextWithPath<'db
     }
   }
 
-  const entities = await db.getRegistriesByPointers(pointers)
+  const entities = await db.getSortedRegistriesByPointers(pointers)
 
   if (entities.length === 0) {
     pointers.forEach((pointer) => {

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -22,7 +22,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
 
   router.get('/status', getStatusHandler)
   router.post('/entities/active', getActiveEntityHandler)
-  router.get('/entities/status/:id', signedFetchMiddleware, getEntityStatusHandler)
+  router.get('/entities/status/:id', getEntityStatusHandler)
   router.get('/entities/status', signedFetchMiddleware, getEntitiesStatusHandler)
   router.get('/queues/status', getQueuesStatuses)
 

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -6,7 +6,7 @@ import { DeploymentToSqs } from '@dcl/schemas/dist/misc/deployments-to-sqs'
 
 export type DbComponent = {
   getSortedRegistriesByOwner(owner: EthAddress): Promise<Registry.DbEntity[]>
-  getRegistriesByPointers(pointers: string[]): Promise<Registry.DbEntity[]>
+  getSortedRegistriesByPointers(pointers: string[]): Promise<Registry.DbEntity[]>
   getRegistryById(id: string): Promise<Registry.DbEntity | null>
   insertRegistry(registry: Registry.DbEntity): Promise<Registry.DbEntity>
   updateRegistriesStatus(ids: string[], status: Registry.Status): Promise<Registry.DbEntity[]>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import { Entity } from '@dcl/schemas'
+import { Entity, EntityType } from '@dcl/schemas'
 
 export namespace Registry {
   export enum SimplifiedStatus {
@@ -20,8 +20,9 @@ export namespace Registry {
     }
   }
 
-  export type DbEntity = Omit<Entity, 'version'> & { deployer: string; bundles: Bundles } & {
+  export type DbEntity = Omit<Entity, 'version' | 'type'> & { deployer: string; bundles: Bundles } & {
     status: Status
+    type: EntityType | 'world'
   }
 
   export type PartialDbEntity = Pick<DbEntity, 'id' | 'pointers' | 'timestamp' | 'status' | 'bundles'>
@@ -43,7 +44,7 @@ type StatusByPlatform = {
 export type EntityStatus = {
   entityId: string
   complete: boolean
-  lods: StatusByPlatform
+  lods?: StatusByPlatform
   assetBundles: StatusByPlatform
   catalyst: Registry.SimplifiedStatus
 }

--- a/test/unit/mocks/db.ts
+++ b/test/unit/mocks/db.ts
@@ -2,7 +2,7 @@ import { DbComponent } from "../../../src/types";
 
 export function createDbMockComponent(): DbComponent {
     return {
-        getRegistriesByPointers: jest.fn(),
+        getSortedRegistriesByPointers: jest.fn(),
         getRegistryById: jest.fn(),
         insertRegistry: jest.fn(),
         upsertRegistryBundle: jest.fn(),


### PR DESCRIPTION
This PR makes the endpoint `GET /entities/status/:id` public so it can be used by internal tools to retrieve bundles status of certain entities.