### PR TITLE
feat: modify worker to do maintenance tasks on db

### DIFF
--- a/src/logic/workers/obsolete-registries-purger.ts
+++ b/src/logic/workers/obsolete-registries-purger.ts
@@ -90,10 +90,11 @@ async function main() {
   }
 
   try {
-    logger.info('Running ANALYZE before purging registries...')
-    await pg.query(SQL`ANALYZE`)
+    logger.info('Purging obsolete registries...')
     await purgeObsoleteRegistries()
-    await pg.query(SQL`VACUUM ANALYZE`)
+    logger.info('Running ANALYZE before purging registries...')
+    await pg.query(SQL`VACUUM ANALYZE registries`)
+    logger.info('Processes completed successfully.')
   } catch (error: any) {
     logger.error('Error during worker execution:', {
       message: error?.message || 'Unknown error',

--- a/src/logic/workers/obsolete-registries-purger.ts
+++ b/src/logic/workers/obsolete-registries-purger.ts
@@ -4,10 +4,11 @@ import { metricDeclarations } from '../../metrics'
 import { createMetricsComponent } from '@well-known-components/metrics'
 import { createPgComponent } from '@well-known-components/pg-component'
 import { createDbAdapter } from '../../adapters/db'
+import { SQL } from 'sql-template-strings'
 
 const BATCH_SIZE = 100
 
-async function main() {
+async function getComponents() {
   const config = await createDotEnvConfigComponent(
     { path: ['.env.default', '.env'] },
     {
@@ -29,11 +30,16 @@ async function main() {
   }
 
   const pg = await createPgComponent({ logs, config, metrics })
-
   const db = createDbAdapter({ pg })
   const logger = logs.getLogger('db-purger-worker')
 
-  try {
+  return { metrics, pg, db, logger }
+}
+
+async function main() {
+  const { metrics, pg, db, logger } = await getComponents()
+
+  async function purgeObsoleteRegistries() {
     const from = Date.now()
     const excludedRegistryIds = new Set<string>()
     let processedCount = 0
@@ -47,7 +53,7 @@ async function main() {
       const failedBatchIds: string[] = []
 
       await Promise.all(
-        registries.map(async (registry) => {
+        registries.map(async (registry: any) => {
           try {
             await db.insertHistoricalRegistry(registry)
             batchIds.push(registry.id)
@@ -81,10 +87,17 @@ async function main() {
     }
 
     logger.info(`Completed processing ${processedCount} registries.`)
+  }
+
+  try {
+    logger.info('Running ANALYZE before purging registries...')
+    await pg.query(SQL`ANALYZE`)
+    await purgeObsoleteRegistries()
+    await pg.query(SQL`VACUUM ANALYZE`)
   } catch (error: any) {
-    logger.error('Error while migrating registries', {
-      error: error?.message || 'Unknown error',
-      stack: error?.stack || 'Unknown stack'
+    logger.error('Error during worker execution:', {
+      message: error?.message || 'Unknown error',
+      stack: error?.stack || 'No stack trace available'
     })
   }
 }


### PR DESCRIPTION
This PR updates the worker that runs every 24 hours to also perform database maintenance tasks, such as removing dead tuples and updating statistics.