### PR TITLE
feat: Store AB Version and include it when responding to `/entities/active`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@dcl/crypto": "^3.4.5",
     "@dcl/platform-crypto-middleware": "^1.1.0",
     "@dcl/platform-server-commons": "^0.0.4",
-    "@dcl/schemas": "^15.7.0",
+    "@dcl/schemas": "https://sdk-team-cdn.decentraland.org/@dcl/schemas/branch/feat/add-version-to-ab-events/dcl-schemas-17.2.1-16744594799.commit-8a01e1d.tgz",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/fetch-component": "^3.0.0",
     "@well-known-components/http-server": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@dcl/crypto": "^3.4.5",
     "@dcl/platform-crypto-middleware": "^1.1.0",
     "@dcl/platform-server-commons": "^0.0.4",
-    "@dcl/schemas": "https://sdk-team-cdn.decentraland.org/@dcl/schemas/branch/feat/add-version-to-ab-events/dcl-schemas-17.2.1-16744594799.commit-8a01e1d.tgz",
+    "@dcl/schemas": "^18.0.0",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/fetch-component": "^3.0.0",
     "@well-known-components/http-server": "^2.1.0",

--- a/src/logic/handlers/status-handler.ts
+++ b/src/logic/handlers/status-handler.ts
@@ -17,11 +17,11 @@ export const createStatusEventHandler = ({
     const platforms: ('webgl' | 'windows' | 'mac')[] = []
 
     if (event.type === Events.Type.ASSET_BUNDLE && event.subType === Events.SubType.AssetBundle.MANUALLY_QUEUED) {
-      const manuallyQueuedEvent = event as AssetBundleConversionManuallyQueuedEvent
+      const { metadata } = event as AssetBundleConversionManuallyQueuedEvent
 
-      entityId = manuallyQueuedEvent.metadata.entityId
-      platforms.push(manuallyQueuedEvent.metadata.platform)
-      isLods = manuallyQueuedEvent.metadata.isLods
+      entityId = metadata.entityId
+      platforms.push(metadata.platform)
+      isLods = metadata.isLods
     } else {
       const deploymentEvent = event as DeploymentToSqs
 

--- a/src/logic/handlers/textures-handler.ts
+++ b/src/logic/handlers/textures-handler.ts
@@ -56,7 +56,8 @@ export const createTexturesEventHandler = ({
           entity = await registryOrchestrator.persistAndRotateStates({
             ...fetchedEntity,
             deployer: '', // cannot infer from textures event
-            bundles: defaultBundles
+            bundles: defaultBundles,
+            version: event.metadata.version
           })
         }
 

--- a/src/migrations/1754383462330_add-version-column.ts
+++ b/src/migrations/1754383462330_add-version-column.ts
@@ -9,10 +9,10 @@ const VERSION_COLUMN = 'version'
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.addColumn(REGISTRIES_TABLE, {
-    [VERSION_COLUMN]: { type: 'varchar(255)', notNull: false }
+    [VERSION_COLUMN]: { type: 'varchar(10)', notNull: false }
   })
   pgm.addColumn(HISTORICAL_REGISTRIES_TABLE, {
-    [VERSION_COLUMN]: { type: 'varchar(255)', notNull: false }
+    [VERSION_COLUMN]: { type: 'varchar(10)', notNull: false }
   })
 }
 

--- a/src/migrations/1754383462330_add-version-column.ts
+++ b/src/migrations/1754383462330_add-version-column.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+const REGISTRIES_TABLE = 'registries'
+const HISTORICAL_REGISTRIES_TABLE = 'historical_registries'
+const VERSION_COLUMN = 'version'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn(REGISTRIES_TABLE, {
+    [VERSION_COLUMN]: { type: 'varchar(255)', notNull: false }
+  })
+  pgm.addColumn(HISTORICAL_REGISTRIES_TABLE, {
+    [VERSION_COLUMN]: { type: 'varchar(255)', notNull: false }
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn(REGISTRIES_TABLE, VERSION_COLUMN)
+  pgm.dropColumn(HISTORICAL_REGISTRIES_TABLE, VERSION_COLUMN)
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -23,6 +23,7 @@ export namespace Registry {
   export type DbEntity = Omit<Entity, 'version' | 'type'> & { deployer: string; bundles: Bundles } & {
     status: Status
     type: EntityType | 'world'
+    version: string | null
   }
 
   export type PartialDbEntity = Pick<DbEntity, 'id' | 'pointers' | 'timestamp' | 'status' | 'bundles'>

--- a/test/unit/logic/handlers/status-handler.spec.ts
+++ b/test/unit/logic/handlers/status-handler.spec.ts
@@ -74,7 +74,8 @@ function createAssetBundleConversionManuallyQueuedEvent(
       entityId,
       platform,
       isLods: false,
-      isPriority: false
+      isPriority: false,
+      version: 'v1'
     }
   }
 }

--- a/test/unit/logic/handlers/textures-handler.spec.ts
+++ b/test/unit/logic/handlers/textures-handler.spec.ts
@@ -30,6 +30,7 @@ describe('textures-handler', () => {
       statusCode: ManifestStatusCode.SUCCESS,
       isLods: false,
       isWorld: false,
+      version: 'v1',
       ...overrides.metadata
     },
     type: Events.Type.ASSET_BUNDLE,
@@ -142,7 +143,8 @@ describe('textures-handler', () => {
             platform: 'windows',
             statusCode: ManifestStatusCode.SUCCESS,
             isLods: false,
-            isWorld: true
+            isWorld: true,
+            version: 'v1'
           }
         })
         const entity = createEntity()
@@ -191,7 +193,8 @@ describe('textures-handler', () => {
             platform: 'windows',
             statusCode: ManifestStatusCode.SUCCESS,
             isLods: false,
-            isWorld: false
+            isWorld: false,
+            version: 'v1'
           }
         })
         const entity = createEntity()
@@ -225,7 +228,8 @@ describe('textures-handler', () => {
             platform: 'mac',
             statusCode: ManifestStatusCode.CONVERSION_ERRORS_TOLERATED,
             isLods: false,
-            isWorld: false
+            isWorld: false,
+            version: 'v1'
           }
         })
         const entity = createEntity()
@@ -259,7 +263,8 @@ describe('textures-handler', () => {
             platform: 'webgl',
             statusCode: ManifestStatusCode.ALREADY_CONVERTED,
             isLods: false,
-            isWorld: false
+            isWorld: false,
+            version: 'v1'
           }
         })
         const entity = createEntity()
@@ -293,7 +298,8 @@ describe('textures-handler', () => {
             platform: 'windows',
             statusCode: ManifestStatusCode.ASSET_BUNDLE_BUILD_FAIL,
             isLods: false,
-            isWorld: false
+            isWorld: false,
+            version: 'v1'
           }
         })
         const entity = createEntity()
@@ -327,7 +333,8 @@ describe('textures-handler', () => {
             platform: 'windows',
             statusCode: ManifestStatusCode.SUCCESS,
             isLods: true,
-            isWorld: false
+            isWorld: false,
+            version: 'v1'
           }
         })
         const entity = createEntity()
@@ -374,7 +381,8 @@ describe('textures-handler', () => {
             platform: 'windows',
             statusCode: ManifestStatusCode.SUCCESS,
             isLods: false,
-            isWorld: false
+            isWorld: false,
+            version: 'v1'
           }
         })
         const entity = createEntity()
@@ -408,7 +416,8 @@ describe('textures-handler', () => {
             platform: 'windows',
             statusCode: ManifestStatusCode.SUCCESS,
             isLods: true,
-            isWorld: false
+            isWorld: false,
+            version: 'v1'
           }
         })
         const entity = createEntity()

--- a/test/unit/logic/registry-orchestrators.spec.ts
+++ b/test/unit/logic/registry-orchestrators.spec.ts
@@ -32,6 +32,7 @@ describe('registry orchestrator should', () => {
         webgl: Registry.SimplifiedStatus.PENDING
       }
     },
+    version: null,
     ...partial
   })
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -114,6 +114,7 @@ export function createRegistryEntity(
     timestamp: 0,
     content: [],
     type: EntityType.SCENE,
+    version: null,
     ...overrideProperties
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,6 +1228,15 @@
     ajv-errors "^3.0.0"
     ajv-keywords "^5.1.0"
 
+"@dcl/schemas@https://sdk-team-cdn.decentraland.org/@dcl/schemas/branch/feat/add-version-to-ab-events/dcl-schemas-17.2.1-16744594799.commit-8a01e1d.tgz":
+  version "17.2.1-16744594799.commit-8a01e1d"
+  resolved "https://sdk-team-cdn.decentraland.org/@dcl/schemas/branch/feat/add-version-to-ab-events/dcl-schemas-17.2.1-16744594799.commit-8a01e1d.tgz#d3061a51f407500c7fa8618b15fdd55ef348e740"
+  dependencies:
+    ajv "^8.11.0"
+    ajv-errors "^3.0.0"
+    ajv-keywords "^5.1.0"
+    mitt "^3.0.1"
+
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz#d1145bf2c20132d6400495d6df4bf59362fd9d56"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,10 +1209,10 @@
     ajv-keywords "^5.1.0"
     mitt "^3.0.1"
 
-"@dcl/schemas@^15.7.0":
-  version "15.7.0"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-15.7.0.tgz#865fdf51ace0c1741fe326b74efac454c03f09bd"
-  integrity sha512-TOlLPFh56JrmyRmRHnMSbMnQpHqXWZ/LRiM8y5lw+gRPMPJvEXL8C0lKbH1Seqsz9Q5K8hF0FTqoTMKBtRiKKg==
+"@dcl/schemas@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-18.0.0.tgz#f4df29b31e998e4c8e51dfb2ec106b7b1e4a6581"
+  integrity sha512-RGG7TUjLslzpsej177CK79WlPKfaAH0SXtW3fYV2btNs93mB6ppGLAh8fx6GBy7kErVBflFRenQFWLJ1gsrNrQ==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"
@@ -1227,15 +1227,6 @@
     ajv "^8.11.0"
     ajv-errors "^3.0.0"
     ajv-keywords "^5.1.0"
-
-"@dcl/schemas@https://sdk-team-cdn.decentraland.org/@dcl/schemas/branch/feat/add-version-to-ab-events/dcl-schemas-17.2.1-16744594799.commit-8a01e1d.tgz":
-  version "17.2.1-16744594799.commit-8a01e1d"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/schemas/branch/feat/add-version-to-ab-events/dcl-schemas-17.2.1-16744594799.commit-8a01e1d.tgz#d3061a51f407500c7fa8618b15fdd55ef348e740"
-  dependencies:
-    ajv "^8.11.0"
-    ajv-errors "^3.0.0"
-    ajv-keywords "^5.1.0"
-    mitt "^3.0.1"
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.1"


### PR DESCRIPTION
Persist the version that comes in the metadata of the AB-related events, and include it in the response of the `/entities/active` endpoint.