### PR TITLE
feat: restrict signed fetch endpoints to only be consumed from explorer client

### DIFF
--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -18,7 +18,8 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
     onError: (err: any) => ({
       error: err.message,
       message: 'This endpoint requires a signed fetch request. See ADR-44.'
-    })
+    }),
+    metadataValidator: (metadata) => metadata?.signer !== 'decentraland-kernel-scene' // prevent requests from scenes
   })
 
   router.get('/status', getStatusHandler)


### PR DESCRIPTION
This PR updates the endpoints restricted by Signed Fetch so they cannot be consumed from scenes in-world (`metadata.signer !== 'decentraland-kernel-scene'`).