### PR TITLE
feat: Improve world scene undeployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@dcl/memory-queue-component": "^2.0.0",
     "@dcl/pg-component": "^0.1.0",
     "@dcl/platform-crypto-middleware": "^1.1.0",
-    "@dcl/schemas": "^24.0.0",
+    "@dcl/schemas": "^25.0.0",
     "@dcl/snapshots-fetcher": "^9.2.2",
     "@dcl/sqs-component": "^2.0.4",
     "@sentry/node": "9.12.0",

--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -1040,31 +1040,6 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
   }
 
   /**
-   * Internal: Gets registries by entity IDs.
-   * @param entityIds - Array of entity IDs
-   * @param executor - Query executor (pg or PoolClient)
-   * @returns Array of registries with their metadata
-   */
-  async function _getRegistriesByIds(entityIds: string[], executor: QueryExecutor = pg): Promise<Registry.DbEntity[]> {
-    if (entityIds.length === 0) {
-      return []
-    }
-
-    const parsedIds = entityIds.map((id) => id.toLowerCase())
-    const query = SQL`
-      SELECT
-        id, type, timestamp, deployer, pointers, content, metadata, status, bundles, versions
-      FROM
-        registries
-      WHERE
-        LOWER(id) = ANY(${parsedIds}::varchar(255)[])
-    `
-
-    const result = await executor.query<Registry.DbEntity>(query)
-    return result.rows
-  }
-
-  /**
    * Atomically gets the processed world parcels and spawn coordinate for a world.
    *
    * This method performs both queries within a database transaction to ensure
@@ -1093,44 +1068,31 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
    *
    * Note: The undeploy event is per-world based, so all entity IDs belong to a single world.
    *
-   * The operation:
-   * 1. Gets registries by IDs to extract the world name
-   * 2. Marks target registries and fallbacks as OBSOLETE (only if created before eventTimestamp)
-   *
    * @param entityIds - Array of entity IDs to undeploy (all belong to the same world)
+   * @param worldName - The world name from the undeployment event
    * @param eventTimestamp - The timestamp of the undeployment event
    * @returns Result containing count and the affected world name
    */
-  async function undeployWorldScenes(entityIds: string[], eventTimestamp: number): Promise<UndeploymentResult> {
+  async function undeployWorldScenes(
+    entityIds: string[],
+    worldName: string,
+    eventTimestamp: number
+  ): Promise<UndeploymentResult> {
+    const normalizedWorldName = worldName.toLowerCase()
+
     if (entityIds.length === 0) {
       return {
         undeployedCount: 0,
-        worldName: null
+        worldName: normalizedWorldName
       }
     }
 
-    return pg.withTransaction(async (client) => {
-      // 1. Get registries to extract the world name
-      const registries = await _getRegistriesByIds(entityIds, client)
+    const undeployedCount = await _undeployRegistries(entityIds, eventTimestamp, pg, normalizedWorldName)
 
-      // Extract world name - all entities belong to the same world
-      let worldName: string | null = null
-      for (const registry of registries) {
-        const name = (registry.metadata as any)?.worldConfiguration?.name
-        if (name) {
-          worldName = name.toLowerCase()
-          break
-        }
-      }
-
-      // 2. Undeploy registries (mark as OBSOLETE) - only those created before eventTimestamp
-      const undeployedCount = await _undeployRegistries(entityIds, eventTimestamp, client, worldName)
-
-      return {
-        undeployedCount,
-        worldName
-      }
-    })
+    return {
+      undeployedCount,
+      worldName: normalizedWorldName
+    }
   }
 
   /**

--- a/src/logic/handlers/undeployment-handler.ts
+++ b/src/logic/handlers/undeployment-handler.ts
@@ -47,12 +47,13 @@ export const createUndeploymentEventHandler = ({
      */
     handle: async (event: WorldScenesUndeploymentEvent): Promise<EventHandlerResult> => {
       const entityIds = event.metadata.scenes.map((scene) => scene.entityId)
+      const worldName = event.metadata.worldName.toLowerCase()
       const eventTimestamp = event.timestamp
 
       try {
-        logger.info('Processing undeployment', { entityIds: entityIds.join(', '), eventTimestamp })
+        logger.info('Processing undeployment', { entityIds: entityIds.join(', '), worldName, eventTimestamp })
 
-        const result = await registry.undeployWorldScenes(entityIds, eventTimestamp)
+        const result = await registry.undeployWorldScenes(entityIds, worldName, eventTimestamp)
 
         logger.info('Undeployment complete', {
           requestedEntityIds: entityIds.join(', '),

--- a/src/logic/registry/component.ts
+++ b/src/logic/registry/component.ts
@@ -13,9 +13,10 @@ export interface IRegistryComponent {
    * Operations are performed in separate transactions with timestamp-based conflict resolution.
    *
    * @param entityIds - Array of entity IDs to undeploy
+   * @param worldName - The world name from the undeployment event
    * @param eventTimestamp - The timestamp of the event that triggered this undeployment
    */
-  undeployWorldScenes(entityIds: string[], eventTimestamp: number): Promise<UndeploymentResult>
+  undeployWorldScenes(entityIds: string[], worldName: string, eventTimestamp: number): Promise<UndeploymentResult>
 
   /**
    * Undeploys all registries belonging to a world and recalculates spawn coordinates.
@@ -147,11 +148,20 @@ export function createRegistryComponent({
     return insertedRegistry
   }
 
-  async function undeployWorldScenes(entityIds: string[], eventTimestamp: number): Promise<UndeploymentResult> {
-    logger.info('Undeploying world scenes', { entityIds: entityIds.join(', '), eventTimestamp })
+  async function undeployWorldScenes(
+    entityIds: string[],
+    worldName: string,
+    eventTimestamp: number
+  ): Promise<UndeploymentResult> {
+    const normalizedWorldName = worldName.toLowerCase()
 
-    // 1. Undeploy registries and get the world name (only those created before eventTimestamp)
-    const result = await db.undeployWorldScenes(entityIds, eventTimestamp)
+    logger.info('Undeploying world scenes', {
+      entityIds: entityIds.join(', '),
+      worldName: normalizedWorldName,
+      eventTimestamp
+    })
+
+    const result = await db.undeployWorldScenes(entityIds, normalizedWorldName, eventTimestamp)
 
     logger.info('Registries marked as obsolete', {
       undeployedCount: result.undeployedCount,
@@ -159,8 +169,7 @@ export function createRegistryComponent({
       eventTimestamp
     })
 
-    // 2. Recalculate spawn coordinate for the affected world (if any)
-    if (result.worldName) {
+    if (result.worldName && result.undeployedCount > 0) {
       await coordinates.recalculateSpawnIfNeeded(result.worldName, eventTimestamp)
     }
 

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -158,7 +158,7 @@ export interface IDbComponent {
     eventTimestamp: number,
     calculateSpawn: (params: SpawnRecalculationParams) => SpawnRecalculationResult
   ): Promise<void>
-  undeployWorldScenes(entityIds: string[], eventTimestamp: number): Promise<UndeploymentResult>
+  undeployWorldScenes(entityIds: string[], worldName: string, eventTimestamp: number): Promise<UndeploymentResult>
   undeployWorldByName(worldName: string, eventTimestamp: number): Promise<UndeploymentResult>
 }
 

--- a/test/integration/undeployment.spec.ts
+++ b/test/integration/undeployment.spec.ts
@@ -518,7 +518,11 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should mark it as OBSOLETE and return the world name', async () => {
-        const result = await components.db.undeployWorldScenes([registry.id], 'scenes-world1.dcl.eth', futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes(
+          [registry.id],
+          'scenes-world1.dcl.eth',
+          futureEventTimestamp
+        )
 
         expect(result.undeployedCount).toBe(1)
         expect(result.worldName).toBe('scenes-world1.dcl.eth')
@@ -554,7 +558,11 @@ test('undeployRegistries', async ({ components }) => {
       it('should NOT mark it as OBSOLETE when event timestamp is before registry timestamp', async () => {
         const pastEventTimestamp = 3000 // Before the registry timestamp of 5000
 
-        const result = await components.db.undeployWorldScenes([registry.id], 'scenes-world-timestamp1.dcl.eth', pastEventTimestamp)
+        const result = await components.db.undeployWorldScenes(
+          [registry.id],
+          'scenes-world-timestamp1.dcl.eth',
+          pastEventTimestamp
+        )
 
         expect(result.undeployedCount).toBe(0)
         expect(result.worldName).toBe('scenes-world-timestamp1.dcl.eth')
@@ -606,7 +614,11 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should mark all as OBSOLETE and return the world name', async () => {
-        const result = await components.db.undeployWorldScenes([registry1.id, registry2.id], 'scenes-world2.dcl.eth', futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes(
+          [registry1.id, registry2.id],
+          'scenes-world2.dcl.eth',
+          futureEventTimestamp
+        )
 
         expect(result.undeployedCount).toBe(2)
         expect(result.worldName).toBe('scenes-world2.dcl.eth')
@@ -636,7 +648,11 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should mark the entity as OBSOLETE and return the provided world name', async () => {
-        const result = await components.db.undeployWorldScenes([registry.id], 'scenes-world3.dcl.eth', futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes(
+          [registry.id],
+          'scenes-world3.dcl.eth',
+          futureEventTimestamp
+        )
 
         expect(result.undeployedCount).toBe(1)
         expect(result.worldName).toBe('scenes-world3.dcl.eth')
@@ -691,7 +707,11 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should mark both the target and the fallback as OBSOLETE', async () => {
-        const result = await components.db.undeployWorldScenes([targetRegistry.id], 'scenes-world4.dcl.eth', futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes(
+          [targetRegistry.id],
+          'scenes-world4.dcl.eth',
+          futureEventTimestamp
+        )
 
         expect(result.undeployedCount).toBe(2)
         expect(result.worldName).toBe('scenes-world4.dcl.eth')
@@ -745,7 +765,11 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should only mark the target entity as OBSOLETE', async () => {
-        const result = await components.db.undeployWorldScenes([targetRegistry.id], 'scenes-world5.dcl.eth', futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes(
+          [targetRegistry.id],
+          'scenes-world5.dcl.eth',
+          futureEventTimestamp
+        )
 
         expect(result.undeployedCount).toBe(1)
         expect(result.worldName).toBe('scenes-world5.dcl.eth')
@@ -797,7 +821,11 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should NOT mark the genesis city FALLBACK scene as OBSOLETE', async () => {
-        const result = await components.db.undeployWorldScenes([worldTargetRegistry.id], 'coord-overlap-world.dcl.eth', futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes(
+          [worldTargetRegistry.id],
+          'coord-overlap-world.dcl.eth',
+          futureEventTimestamp
+        )
 
         expect(result.undeployedCount).toBe(1)
         expect(result.worldName).toBe('coord-overlap-world.dcl.eth')

--- a/test/integration/undeployment.spec.ts
+++ b/test/integration/undeployment.spec.ts
@@ -474,23 +474,24 @@ test('undeployRegistries', async ({ components }) => {
     })
 
     describe('and an empty array is provided', () => {
-      it('should return 0 count and null world name', async () => {
-        const result = await components.db.undeployWorldScenes([], futureEventTimestamp)
+      it('should return 0 count and the world name', async () => {
+        const result = await components.db.undeployWorldScenes([], 'some-world.dcl.eth', futureEventTimestamp)
 
         expect(result.undeployedCount).toBe(0)
-        expect(result.worldName).toBeNull()
+        expect(result.worldName).toBe('some-world.dcl.eth')
       })
     })
 
     describe('and the entity IDs do not exist in the database', () => {
-      it('should return 0 count and null world name', async () => {
+      it('should return 0 count and the world name', async () => {
         const result = await components.db.undeployWorldScenes(
           ['non-existent-entity-1', 'non-existent-entity-2'],
+          'some-world.dcl.eth',
           futureEventTimestamp
         )
 
         expect(result.undeployedCount).toBe(0)
-        expect(result.worldName).toBeNull()
+        expect(result.worldName).toBe('some-world.dcl.eth')
       })
     })
 
@@ -517,7 +518,7 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should mark it as OBSOLETE and return the world name', async () => {
-        const result = await components.db.undeployWorldScenes([registry.id], futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes([registry.id], 'scenes-world1.dcl.eth', futureEventTimestamp)
 
         expect(result.undeployedCount).toBe(1)
         expect(result.worldName).toBe('scenes-world1.dcl.eth')
@@ -553,7 +554,7 @@ test('undeployRegistries', async ({ components }) => {
       it('should NOT mark it as OBSOLETE when event timestamp is before registry timestamp', async () => {
         const pastEventTimestamp = 3000 // Before the registry timestamp of 5000
 
-        const result = await components.db.undeployWorldScenes([registry.id], pastEventTimestamp)
+        const result = await components.db.undeployWorldScenes([registry.id], 'scenes-world-timestamp1.dcl.eth', pastEventTimestamp)
 
         expect(result.undeployedCount).toBe(0)
         expect(result.worldName).toBe('scenes-world-timestamp1.dcl.eth')
@@ -605,7 +606,7 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should mark all as OBSOLETE and return the world name', async () => {
-        const result = await components.db.undeployWorldScenes([registry1.id, registry2.id], futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes([registry1.id, registry2.id], 'scenes-world2.dcl.eth', futureEventTimestamp)
 
         expect(result.undeployedCount).toBe(2)
         expect(result.worldName).toBe('scenes-world2.dcl.eth')
@@ -634,11 +635,11 @@ test('undeployRegistries', async ({ components }) => {
         await createRegistryOnDatabase(registry)
       })
 
-      it('should mark the entity as OBSOLETE and return null world name', async () => {
-        const result = await components.db.undeployWorldScenes([registry.id], futureEventTimestamp)
+      it('should mark the entity as OBSOLETE and return the provided world name', async () => {
+        const result = await components.db.undeployWorldScenes([registry.id], 'scenes-world3.dcl.eth', futureEventTimestamp)
 
         expect(result.undeployedCount).toBe(1)
-        expect(result.worldName).toBeNull()
+        expect(result.worldName).toBe('scenes-world3.dcl.eth')
 
         const updatedRegistry = await components.db.getRegistryById(registry.id)
         expect(updatedRegistry?.status).toBe(Registry.Status.OBSOLETE)
@@ -690,7 +691,7 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should mark both the target and the fallback as OBSOLETE', async () => {
-        const result = await components.db.undeployWorldScenes([targetRegistry.id], futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes([targetRegistry.id], 'scenes-world4.dcl.eth', futureEventTimestamp)
 
         expect(result.undeployedCount).toBe(2)
         expect(result.worldName).toBe('scenes-world4.dcl.eth')
@@ -744,7 +745,7 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should only mark the target entity as OBSOLETE', async () => {
-        const result = await components.db.undeployWorldScenes([targetRegistry.id], futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes([targetRegistry.id], 'scenes-world5.dcl.eth', futureEventTimestamp)
 
         expect(result.undeployedCount).toBe(1)
         expect(result.worldName).toBe('scenes-world5.dcl.eth')
@@ -796,7 +797,7 @@ test('undeployRegistries', async ({ components }) => {
       })
 
       it('should NOT mark the genesis city FALLBACK scene as OBSOLETE', async () => {
-        const result = await components.db.undeployWorldScenes([worldTargetRegistry.id], futureEventTimestamp)
+        const result = await components.db.undeployWorldScenes([worldTargetRegistry.id], 'coord-overlap-world.dcl.eth', futureEventTimestamp)
 
         expect(result.undeployedCount).toBe(1)
         expect(result.worldName).toBe('coord-overlap-world.dcl.eth')

--- a/test/unit/logic/handlers/undeployment-handler.spec.ts
+++ b/test/unit/logic/handlers/undeployment-handler.spec.ts
@@ -13,7 +13,7 @@ describe('when handling undeployment events', () => {
     key: 'test-key',
     timestamp: Date.now(),
     metadata: {
-      worldName: 'test-world',
+      worldName: 'Test-World',
       scenes
     }
   })
@@ -57,7 +57,7 @@ describe('when handling undeployment events', () => {
           subType: Events.SubType.Worlds.WORLD_SCENES_UNDEPLOYMENT,
           key: 'test-key',
           timestamp: Date.now(),
-          metadata: { worldName: 'test-world', scenes: [{ entityId: 'entity-1', baseParcel: '0,0' }] }
+          metadata: { worldName: 'Test-World', scenes: [{ entityId: 'entity-1', baseParcel: '0,0' }] }
         }
       })
 
@@ -75,7 +75,7 @@ describe('when handling undeployment events', () => {
           subType: Events.SubType.AssetBundle.CONVERTED,
           key: 'test-key',
           timestamp: Date.now(),
-          metadata: { worldName: 'test-world', scenes: [{ entityId: 'entity-1', baseParcel: '0,0' }] }
+          metadata: { worldName: 'Test-World', scenes: [{ entityId: 'entity-1', baseParcel: '0,0' }] }
         }
       })
 
@@ -126,10 +126,10 @@ describe('when handling undeployment events', () => {
         })
       })
 
-      it('should undeploy the world scenes for the given entity IDs', async () => {
+      it('should undeploy the world scenes for the given entity IDs and lowercased world name', async () => {
         await handler.handle(event)
 
-        expect(registry.undeployWorldScenes).toHaveBeenCalledWith(['entity-1', 'entity-2'], event.timestamp)
+        expect(registry.undeployWorldScenes).toHaveBeenCalledWith(['entity-1', 'entity-2'], 'test-world', event.timestamp)
       })
 
       it('should return ok', async () => {

--- a/test/unit/logic/handlers/undeployment-handler.spec.ts
+++ b/test/unit/logic/handlers/undeployment-handler.spec.ts
@@ -129,7 +129,11 @@ describe('when handling undeployment events', () => {
       it('should undeploy the world scenes for the given entity IDs and lowercased world name', async () => {
         await handler.handle(event)
 
-        expect(registry.undeployWorldScenes).toHaveBeenCalledWith(['entity-1', 'entity-2'], 'test-world', event.timestamp)
+        expect(registry.undeployWorldScenes).toHaveBeenCalledWith(
+          ['entity-1', 'entity-2'],
+          'test-world',
+          event.timestamp
+        )
       })
 
       it('should return ok', async () => {

--- a/test/unit/logic/registry/component.spec.ts
+++ b/test/unit/logic/registry/component.spec.ts
@@ -335,14 +335,16 @@ describe('when using the registry component', () => {
 
   describe('and calling undeployWorldScenes', () => {
     let entityIds: string[]
+    let worldName: string
     let eventTimestamp: number
 
     beforeEach(() => {
       entityIds = ['entity-1', 'entity-2']
+      worldName = 'Test-World'
       eventTimestamp = Date.now()
     })
 
-    describe('when the undeployment is successful and a world is found', () => {
+    describe('when the undeployment is successful', () => {
       beforeEach(() => {
         db.undeployWorldScenes.mockResolvedValue({
           undeployedCount: 2,
@@ -350,20 +352,20 @@ describe('when using the registry component', () => {
         })
       })
 
-      it('should undeploy the world scenes for the given entity IDs with the event timestamp', async () => {
-        await component.undeployWorldScenes(entityIds, eventTimestamp)
+      it('should undeploy the world scenes for the given entity IDs with the lowercased world name and event timestamp', async () => {
+        await component.undeployWorldScenes(entityIds, worldName, eventTimestamp)
 
-        expect(db.undeployWorldScenes).toHaveBeenCalledWith(entityIds, eventTimestamp)
+        expect(db.undeployWorldScenes).toHaveBeenCalledWith(entityIds, 'test-world', eventTimestamp)
       })
 
       it('should recalculate the spawn coordinates for the affected world', async () => {
-        await component.undeployWorldScenes(entityIds, eventTimestamp)
+        await component.undeployWorldScenes(entityIds, worldName, eventTimestamp)
 
         expect(coordinates.recalculateSpawnIfNeeded).toHaveBeenCalledWith('test-world', eventTimestamp)
       })
 
       it('should return the undeployment result', async () => {
-        const result = await component.undeployWorldScenes(entityIds, eventTimestamp)
+        const result = await component.undeployWorldScenes(entityIds, worldName, eventTimestamp)
 
         expect(result).toEqual({
           undeployedCount: 2,
@@ -372,26 +374,26 @@ describe('when using the registry component', () => {
       })
     })
 
-    describe('when no world is found in the registries', () => {
+    describe('when no registries are undeployed', () => {
       beforeEach(() => {
         db.undeployWorldScenes.mockResolvedValue({
           undeployedCount: 0,
-          worldName: null
+          worldName: 'test-world'
         })
       })
 
       it('should not recalculate spawn coordinates', async () => {
-        await component.undeployWorldScenes(entityIds, eventTimestamp)
+        await component.undeployWorldScenes(entityIds, worldName, eventTimestamp)
 
         expect(coordinates.recalculateSpawnIfNeeded).not.toHaveBeenCalled()
       })
 
-      it('should return the undeployment result with null worldName', async () => {
-        const result = await component.undeployWorldScenes(entityIds, eventTimestamp)
+      it('should return the undeployment result', async () => {
+        const result = await component.undeployWorldScenes(entityIds, worldName, eventTimestamp)
 
         expect(result).toEqual({
           undeployedCount: 0,
-          worldName: null
+          worldName: 'test-world'
         })
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,10 +1263,10 @@
     ajv-keywords "^5.1.0"
     mitt "^3.0.1"
 
-"@dcl/schemas@^24.0.0":
-  version "24.0.0"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-24.0.0.tgz#ed24a9c6460b775c3fd732b9c5f767ebbd3c7acd"
-  integrity sha512-hSFZrnC8fz/uFvMOSENv78kRtiosqxkjvCHAX0EbXCAFqE4rAplzG0baXRTrw0Hxrc2KD5chB1JCaKPV0sO6SQ==
+"@dcl/schemas@^25.0.0":
+  version "25.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-25.0.0.tgz#68e6e85acfe5e04afd88f9c0c002fe5f4f51bb8f"
+  integrity sha512-EtXXmPTgCDdVP7q2/5xkhSUBvVh+3bniH/Z7S5Vq/wdO3jQC5MZJNkvAZRkmgUUoydvp0z7Ur9Zy6zsgrDanqw==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"


### PR DESCRIPTION
The `WorldScenesUndeploymentEvent` already carries the world name in `event.metadata.worldName`. Previously, `undeployWorldScenes` in the DB adapter ignored this and instead opened a transaction to fetch registries by their entity IDs, then extracted the world name from the first registry's `metadata.worldConfiguration.name`. This was unnecessary work: an extra query inside a transaction just to derive information that the caller already had.

Relying on entity metadata also meant the world name could be `null` when the matched registries lacked a `worldConfiguration` field, which made the FALLBACK sweep in `_undeployRegistries` fall back to Genesis City scoping — a silent mismatch for world-originated events.

## What changed

### Handler extracts and lowercases the world name

`undeployment-handler` now reads `event.metadata.worldName`, lowercases it, and passes it through to `registry.undeployWorldScenes(entityIds, worldName, eventTimestamp)`.

### Registry component forwards the world name

`IRegistryComponent.undeployWorldScenes` gains a `worldName` parameter. The component normalises it to lowercase and passes it straight to the DB adapter. Spawn recalculation now guards on `undeployedCount > 0` (consistent with `undeployWorld`) instead of checking for a non-null `worldName`, since the world name is always present now.

### DB adapter no longer queries for the world name

`db.undeployWorldScenes` receives the world name directly, so:

- The `_getRegistriesByIds` lookup is removed — no need to fetch registries just to read their metadata.
- The `pg.withTransaction` wrapper is removed — a single `_undeployRegistries` call doesn't require transactional consistency across multiple reads/writes.
- The `_getRegistriesByIds` helper function was deleted entirely as it had no remaining callers.
