### PR TITLE
feat: GIN index for non-worlds scenes faster look-up

### DIFF
--- a/src/migrations/1769400000000_non-world-pointers-index.ts
+++ b/src/migrations/1769400000000_non-world-pointers-index.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Partial GIN index on pointers for non-world entities (Genesis City).
+  // The existing GIN index on pointers covers all rows, but queries that
+  // filter with metadata->'worldConfiguration'->>'name' IS NULL cannot
+  // use the partial index idx_registries_world_configuration_name (which
+  // only covers IS NOT NULL rows). This index lets PostgreSQL satisfy both
+  // the array overlap and the IS NULL condition at index-scan time,
+  // avoiding per-row JSONB extraction.
+  pgm.createIndex('registries', 'pointers', {
+    method: 'gin',
+    name: 'idx_registries_pointers_non_world',
+    where: "metadata->'worldConfiguration'->>'name' IS NULL"
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('registries', 'pointers', {
+    name: 'idx_registries_pointers_non_world',
+    ifExists: true
+  })
+}


### PR DESCRIPTION
Queries filtering Genesis City entities by coordinate (`pointers && ...`) with `metadata->'worldConfiguration'->>'name' IS NULL` cannot use the existing partial index `idx_registries_world_configuration_name` (_which only covers IS NOT NULL rows_), causing per-row JSONB extraction on every candidate.

This PR adds a partial GIN index on pointers for non-world rows, allowing PostgreSQL to satisfy both the array overlap and the IS NULL condition at index-scan time. The index has been tested manually in dev environment and is working as expected.