### PR TITLE
feat: Add tests for failed conversions

### DIFF
--- a/test/integration/entities-endpoints.spec.ts
+++ b/test/integration/entities-endpoints.spec.ts
@@ -212,9 +212,7 @@ test('POST /entities endpoints', async function ({ components }) {
               const parsedResponse = await response.json()
 
               expect(parsedResponse).toHaveLength(2)
-              expect(parsedResponse).toEqual(
-                expect.arrayContaining(parseResponse([registryA, registryB]))
-              )
+              expect(parsedResponse).toEqual(expect.arrayContaining(parseResponse([registryA, registryB])))
             })
           })
 

--- a/test/integration/entities-endpoints.spec.ts
+++ b/test/integration/entities-endpoints.spec.ts
@@ -211,7 +211,10 @@ test('POST /entities endpoints', async function ({ components }) {
               })
               const parsedResponse = await response.json()
 
-              expect(parsedResponse).toEqual(parseResponse([registryA, registryB]))
+              expect(parsedResponse).toHaveLength(2)
+              expect(parsedResponse).toEqual(
+                expect.arrayContaining(parseResponse([registryA, registryB]))
+              )
             })
           })
 
@@ -243,6 +246,87 @@ test('POST /entities endpoints', async function ({ components }) {
 
               expect(parsedResponse).toEqual(parseResponse([registryA]))
             })
+          })
+        })
+
+        describe('and the most recent genesis city scene is FAILED with an older FALLBACK scene', () => {
+          let failedRegistry: Registry.DbEntity
+          let fallbackRegistry: Registry.DbEntity
+
+          beforeEach(async () => {
+            fallbackRegistry = createRegistryEntity(
+              identity.realAccount.address,
+              Registry.Status.FALLBACK,
+              Registry.SimplifiedStatus.COMPLETE,
+              { id: 'fallback-genesis-scene', pointers: ['2000,2000'], timestamp: 1000 }
+            )
+            failedRegistry = createRegistryEntity(
+              identity.realAccount.address,
+              Registry.Status.FAILED,
+              Registry.SimplifiedStatus.FAILED,
+              { id: 'failed-genesis-scene', pointers: ['2000,2000'], timestamp: 2000 }
+            )
+            await createRegistryOnDatabase(fallbackRegistry)
+            await createRegistryOnDatabase(failedRegistry)
+          })
+
+          it('should return the fallback scene and not the failed one', async () => {
+            const response = await fetchLocally('POST', path, undefined, {
+              pointers: ['2000,2000']
+            })
+            const parsedResponse = await response.json()
+
+            expect(parsedResponse).toEqual(parseResponse([fallbackRegistry]))
+          })
+        })
+
+        describe('and the most recent world scene is FAILED with an older FALLBACK scene', () => {
+          let failedRegistry: Registry.DbEntity
+          let fallbackRegistry: Registry.DbEntity
+
+          beforeEach(async () => {
+            fallbackRegistry = createRegistryEntity(
+              identity.realAccount.address,
+              Registry.Status.FALLBACK,
+              Registry.SimplifiedStatus.COMPLETE,
+              {
+                id: 'fallback-world-scene',
+                type: 'world',
+                pointers: ['3000,3000'],
+                timestamp: 1000,
+                metadata: { worldConfiguration: { name: 'failed-test-world.dcl.eth' } }
+              }
+            )
+            failedRegistry = createRegistryEntity(
+              identity.realAccount.address,
+              Registry.Status.FAILED,
+              Registry.SimplifiedStatus.FAILED,
+              {
+                id: 'failed-world-scene',
+                type: 'world',
+                pointers: ['3000,3000'],
+                timestamp: 2000,
+                metadata: { worldConfiguration: { name: 'failed-test-world.dcl.eth' } }
+              }
+            )
+            await createRegistryOnDatabase(fallbackRegistry)
+            await createRegistryOnDatabase(failedRegistry)
+          })
+
+          it('should return the fallback scene and not the failed one', async () => {
+            const response = await fetchLocally(
+              'POST',
+              path,
+              undefined,
+              {
+                pointers: ['3000,3000']
+              },
+              {},
+              { world_name: 'failed-test-world.dcl.eth' }
+            )
+            const parsedResponse = await response.json()
+
+            expect(parsedResponse).toEqual(parseResponse([fallbackRegistry]))
           })
         })
 

--- a/test/integration/get-world-manifest.spec.ts
+++ b/test/integration/get-world-manifest.spec.ts
@@ -119,6 +119,81 @@ test('GET /worlds/:worldName/manifest', async ({ components }) => {
       })
     })
 
+    describe('and the world has a FAILED scene with an older FALLBACK scene', () => {
+      const worldName = 'test-world-failed.dcl.eth'
+
+      beforeEach(async () => {
+        await createWorldRegistry(worldName, ['0,0', '1,0'], {
+          id: 'world-manifest-fallback-entity',
+          timestamp: 1000,
+          status: Registry.Status.FALLBACK
+        })
+        await createWorldRegistry(worldName, ['0,0', '1,0', '2,0'], {
+          id: 'world-manifest-failed-entity',
+          timestamp: 2000,
+          status: Registry.Status.FAILED,
+          bundles: {
+            assets: {
+              windows: Registry.SimplifiedStatus.FAILED,
+              mac: Registry.SimplifiedStatus.COMPLETE,
+              webgl: Registry.SimplifiedStatus.COMPLETE
+            },
+            lods: {
+              windows: Registry.SimplifiedStatus.PENDING,
+              mac: Registry.SimplifiedStatus.PENDING,
+              webgl: Registry.SimplifiedStatus.PENDING
+            }
+          }
+        })
+        await components.extendedDb.insertSpawnCoordinate(worldName, 0, 0, true, 1000)
+      })
+
+      it('should respond with only the fallback scene parcels and not include the failed scene parcels', async () => {
+        const response = await fetchLocally('GET', `/worlds/${worldName}/manifest`, undefined, undefined)
+
+        expect(response.status).toBe(200)
+        const body = await response.json()
+        expect(body.occupied).toEqual(expect.arrayContaining(['0,0', '1,0']))
+        expect(body.occupied).not.toContain('2,0')
+        expect(body.spawn_coordinate).toEqual({ x: 0, y: 0 })
+        expect(body.total).toBe(2)
+      })
+    })
+
+    describe('and the world has only FAILED scenes', () => {
+      const worldName = 'test-world-all-failed.dcl.eth'
+
+      beforeEach(async () => {
+        await createWorldRegistry(worldName, ['0,0', '1,0'], {
+          id: 'world-manifest-all-failed-entity',
+          timestamp: 1000,
+          status: Registry.Status.FAILED,
+          bundles: {
+            assets: {
+              windows: Registry.SimplifiedStatus.FAILED,
+              mac: Registry.SimplifiedStatus.COMPLETE,
+              webgl: Registry.SimplifiedStatus.COMPLETE
+            },
+            lods: {
+              windows: Registry.SimplifiedStatus.PENDING,
+              mac: Registry.SimplifiedStatus.PENDING,
+              webgl: Registry.SimplifiedStatus.PENDING
+            }
+          }
+        })
+      })
+
+      it('should respond with an empty manifest with default spawn coordinate', async () => {
+        const response = await fetchLocally('GET', `/worlds/${worldName}/manifest`, undefined, undefined)
+
+        expect(response.status).toBe(200)
+        const body = await response.json()
+        expect(body.occupied).toEqual([])
+        expect(body.spawn_coordinate).toEqual({ x: 0, y: 0 })
+        expect(body.total).toBe(0)
+      })
+    })
+
     describe('and the world has no deployed scenes', () => {
       const worldName = 'empty-world.dcl.eth'
 

--- a/test/unit/logic/registry/component.spec.ts
+++ b/test/unit/logic/registry/component.spec.ts
@@ -331,6 +331,61 @@ describe('when using the registry component', () => {
         expect(db.updateRegistriesStatus).toHaveBeenCalledWith([olderCompleteRegistry.id], Registry.Status.FALLBACK)
       })
     })
+
+    describe('when there is an older complete genesis city scene and the newer one fails one platform', () => {
+      let registry: Registry.DbEntity
+      let olderCompleteRegistry: Registry.DbEntity
+
+      beforeEach(() => {
+        olderCompleteRegistry = createRelativeRegistry(-1000, Registry.Status.COMPLETE, 'older-complete')
+        db.getRelatedRegistries.mockResolvedValue([olderCompleteRegistry])
+        registry = withAssetStatus(
+          createRegistry(),
+          Registry.SimplifiedStatus.COMPLETE,
+          Registry.SimplifiedStatus.FAILED
+        )
+      })
+
+      it('should mark the registry as failed', async () => {
+        await component.persistAndRotateStates(registry)
+
+        expect(db.insertRegistry).toHaveBeenCalledWith({ ...registry, status: Registry.Status.FAILED })
+      })
+
+      it('should mark the older complete registry as fallback', async () => {
+        await component.persistAndRotateStates(registry)
+
+        expect(db.updateRegistriesStatus).toHaveBeenCalledWith([olderCompleteRegistry.id], Registry.Status.FALLBACK)
+      })
+    })
+
+    describe('when there is an older complete world scene and the newer one fails one platform', () => {
+      let registry: Registry.DbEntity
+      let olderCompleteRegistry: Registry.DbEntity
+
+      beforeEach(() => {
+        olderCompleteRegistry = createRelativeRegistry(-1000, Registry.Status.COMPLETE, 'older-complete')
+        olderCompleteRegistry.metadata = { worldConfiguration: { name: 'test-world.dcl.eth' } }
+        db.getRelatedRegistries.mockResolvedValue([olderCompleteRegistry])
+        registry = withAssetStatus(
+          createRegistry({ metadata: { worldConfiguration: { name: 'test-world.dcl.eth' } } }),
+          Registry.SimplifiedStatus.COMPLETE,
+          Registry.SimplifiedStatus.FAILED
+        )
+      })
+
+      it('should mark the registry as failed', async () => {
+        await component.persistAndRotateStates(registry)
+
+        expect(db.insertRegistry).toHaveBeenCalledWith({ ...registry, status: Registry.Status.FAILED })
+      })
+
+      it('should mark the older complete world scene as fallback', async () => {
+        await component.persistAndRotateStates(registry)
+
+        expect(db.updateRegistriesStatus).toHaveBeenCalledWith([olderCompleteRegistry.id], Registry.Status.FALLBACK)
+      })
+    })
   })
 
   describe('and calling undeployWorldScenes', () => {


### PR DESCRIPTION
When a scene deployment fails asset bundle conversion on one platform (e.g., mac succeeds but windows fails), the registry is marked as `FAILED`. If there was a previous `COMPLETE` registry for the same pointers, it gets demoted to `FALLBACK` — which the system continues to serve, since both `COMPLETE` and `FALLBACK` statuses are treated as active when querying entities and building world manifests.

This behavior was already working correctly in the codebase but lacked test coverage for the specific scenario of partial platform failure with fallback preservation. This PR adds that coverage.

## Why

The fallback mechanism is critical for ensuring that clients always receive a working scene even when a newer deployment fails conversion. Without explicit tests for this path, a future refactor could inadvertently break it — leaving users with no scene served when only one platform's conversion fails.

The world manifest also relies on the same status filtering (`COMPLETE` and `FALLBACK` only), so a failed scene must not pollute the manifest's occupied parcels. This needed dedicated test coverage as well.

## What changed

### Unit tests (`test/unit/logic/registry/component.spec.ts`)

Added two test cases to `persistAndRotateStates` covering partial platform failure (mac `COMPLETE`, windows `FAILED`) for both genesis city scenes and world scenes. These verify that:

- The newer registry is marked as `FAILED`
- The older `COMPLETE` registry is demoted to `FALLBACK` (and thus remains served)

### Integration tests (`test/integration/entities-endpoints.spec.ts`)

Added tests for both `/entities/active` and `/entities/versions` endpoints verifying that when the most recent scene is `FAILED` and an older `FALLBACK` exists:

- **Genesis city scenes**: Only the fallback scene is returned
- **World scenes**: Only the fallback scene is returned (queried with `world_name`)

Also fixed a pre-existing flaky test (`should return multiple entities`) that was asserting exact array order on results that could come back in any order from the database. Changed to order-independent matching with `expect.arrayContaining`.

### Integration tests (`test/integration/get-world-manifest.spec.ts`)

Added two test cases for the world manifest endpoint:

- **FAILED scene with older FALLBACK**: The manifest includes only the fallback scene's parcels, excluding the failed scene's additional parcels
- **Only FAILED scenes**: The manifest returns an empty occupied list with the default spawn coordinate `{x: 0, y: 0}`
