### PR TITLE
fix: Atomic persisting and rotating

### DIFF
--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -1174,6 +1174,304 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     })
   }
 
+  /**
+   * Internal: Updates the bundle status for a specific platform within a transaction.
+   * Sets the simplified status (PENDING, COMPLETE, FAILED) for either the assets or lods bundle type.
+   *
+   * @param id - The entity ID to update
+   * @param platform - The platform to update (e.g., 'windows', 'mac', 'webgl')
+   * @param lods - Whether to update the LODs bundle (true) or assets bundle (false)
+   * @param status - The new simplified status for the bundle
+   * @param executor - The transaction client to use for the query
+   * @returns The updated registry entity, or null if the entity was not found
+   */
+  async function _upsertRegistryBundle(
+    id: string,
+    platform: string,
+    lods: boolean,
+    status: Registry.SimplifiedStatus,
+    executor: QueryExecutor
+  ): Promise<Registry.DbEntity | null> {
+    const bundleType = lods ? 'lods' : 'assets'
+
+    const query: SQLStatement = SQL`
+      UPDATE registries
+      SET
+        bundles = jsonb_set(
+          registries.bundles,
+          ARRAY[${bundleType}::text, ${platform}::text],
+          to_jsonb(${status}::text)
+        )
+      WHERE LOWER(registries.id) = ${id.toLocaleLowerCase()}
+      RETURNING *
+    `
+
+    const result = await executor.query<Registry.DbEntity>(query)
+    return result.rows[0] || null
+  }
+
+  /**
+   * Internal: Updates the version and build date for a specific platform's asset bundle within a transaction.
+   *
+   * @param id - The entity ID to update
+   * @param platform - The platform to update (e.g., 'windows', 'mac', 'webgl')
+   * @param version - The asset bundle version string
+   * @param buildDate - The ISO date string of when the bundle was built
+   * @param executor - The transaction client to use for the query
+   * @returns The updated registry entity, or null if the entity was not found
+   */
+  async function _updateRegistryVersionWithBuildDate(
+    id: string,
+    platform: string,
+    version: string,
+    buildDate: string,
+    executor: QueryExecutor
+  ): Promise<Registry.DbEntity | null> {
+    const bundleType = 'assets'
+    const versionData = { version, buildDate }
+    const query: SQLStatement = SQL`
+      UPDATE registries
+      SET
+        versions = jsonb_set(
+          COALESCE(registries.versions, '{}'::jsonb),
+          ARRAY[${bundleType}::text, ${platform}::text],
+          to_jsonb(${versionData}::jsonb)
+        )
+      WHERE LOWER(registries.id) = ${id.toLocaleLowerCase()}
+      RETURNING *
+    `
+
+    const result = await executor.query<Registry.DbEntity>(query)
+    return result.rows[0] || null
+  }
+
+  /**
+   * Internal: Gets registries related to a given registry by overlapping pointers within a transaction.
+   * Filters by world name context (same as the public getRelatedRegistries) and excludes OBSOLETE entities.
+   *
+   * @param registry - The registry to find related entities for (uses pointers, id, and metadata)
+   * @param executor - The transaction client to use for the query
+   * @returns Related registries that share pointers within the same context (world or Genesis City)
+   */
+  async function _getRelatedRegistries(
+    registry: Pick<Registry.DbEntity, 'pointers' | 'id' | 'metadata'>,
+    executor: QueryExecutor
+  ): Promise<Registry.PartialDbEntity[]> {
+    const worldName = (registry.metadata as any)?.worldConfiguration?.name as string | undefined
+    const lowerCasePointers = registry.pointers.map((p) => p.toLowerCase())
+
+    const query: SQLStatement = SQL`
+      SELECT
+        id, pointers, timestamp, status, bundles, versions
+      FROM
+        registries
+      WHERE
+        pointers && ${lowerCasePointers}::varchar(255)[]
+        AND LOWER(id) != ${registry.id.toLocaleLowerCase()}
+        AND status != ${Registry.Status.OBSOLETE}
+    `
+
+    if (worldName) {
+      const normalizedWorldName = worldName.toLowerCase()
+      query.append(SQL`
+        AND LOWER(metadata->'worldConfiguration'->>'name') = ${normalizedWorldName}
+      `)
+    } else {
+      query.append(SQL`
+        AND metadata->'worldConfiguration'->>'name' IS NULL
+      `)
+    }
+
+    query.append(SQL`
+      ORDER BY timestamp DESC
+    `)
+
+    const result = await executor.query<Registry.PartialDbEntity>(query)
+    return result.rows
+  }
+
+  /**
+   * Internal: Inserts or updates a registry entity within a transaction.
+   * Uses an upsert (INSERT ... ON CONFLICT DO UPDATE) to handle both new and existing entities.
+   * Preserves the existing deployer if the new deployer is empty.
+   *
+   * @param registry - The full registry entity to insert or update
+   * @param executor - The transaction client to use for the query
+   * @returns The inserted or updated registry entity
+   */
+  async function _insertRegistry(registry: Registry.DbEntity, executor: QueryExecutor): Promise<Registry.DbEntity> {
+    const query: SQLStatement = SQL`
+        INSERT INTO registries (
+          id, type, timestamp, deployer, pointers, content, metadata, status, bundles, versions
+        )
+        VALUES (
+          ${registry.id},
+          ${registry.type},
+          ${registry.timestamp},
+          ${registry.deployer.toLocaleLowerCase()},
+          ${registry.pointers}::varchar(255)[],
+          ${JSON.stringify(registry.content)}::jsonb,
+          ${JSON.stringify(registry.metadata)}::jsonb,
+          ${registry.status},
+          ${JSON.stringify(registry.bundles)}::jsonb,
+          ${JSON.stringify(registry.versions)}::jsonb
+        )
+        ON CONFLICT (id) DO UPDATE
+        SET
+          type = EXCLUDED.type,
+          timestamp = EXCLUDED.timestamp,
+          pointers = EXCLUDED.pointers,
+          content = EXCLUDED.content,
+          metadata = EXCLUDED.metadata,
+          status = EXCLUDED.status,
+          bundles = EXCLUDED.bundles,
+          deployer = CASE
+            WHEN EXCLUDED.deployer != '' THEN EXCLUDED.deployer
+            ELSE registries.deployer
+          END,
+          versions = EXCLUDED.versions
+        RETURNING
+          id,
+          type,
+          timestamp,
+          deployer,
+          pointers,
+          content,
+          metadata,
+          status,
+          bundles,
+          versions
+      `
+
+    const result = await executor.query<Registry.DbEntity>(query)
+    return result.rows[0]
+  }
+
+  /**
+   * Internal: Updates the status of multiple registries by their IDs within a transaction.
+   *
+   * @param ids - Array of entity IDs to update
+   * @param status - The new status to set
+   * @param executor - The transaction client to use for the query
+   * @returns The updated registry entities
+   */
+  async function _updateRegistriesStatus(
+    ids: string[],
+    status: Registry.Status,
+    executor: QueryExecutor
+  ): Promise<Registry.DbEntity[]> {
+    const parsedIds = ids.map((id) => id.toLocaleLowerCase())
+
+    const query: SQLStatement = SQL`
+        UPDATE registries
+        SET status = ${status}
+        WHERE LOWER(id) = ANY(${parsedIds}::varchar(255)[])
+        RETURNING
+          id,
+          type,
+          timestamp,
+          pointers,
+          deployer,
+          content,
+          metadata,
+          status,
+          bundles,
+          versions
+      `
+
+    const result = await executor.query<Registry.DbEntity>(query)
+    return result.rows || null
+  }
+
+  /**
+   * Atomically updates a bundle, optionally updates the version, reads the current entity state and
+   * related registries, then persists the registry with rotated statuses — all within a single transaction.
+   *
+   * This prevents race conditions where concurrent texture events for the same entity could result in
+   * a stale thread overwriting a correct COMPLETE status back to PENDING, because the status determination
+   * always uses the current DB state (after the bundle update) rather than the caller's potentially stale snapshot.
+   *
+   * The transaction executes the following steps:
+   * 1. Updates the bundle status for the specified platform
+   * 2. Optionally updates the version and build date
+   * 3. Reads related registries (consistent within the transaction)
+   * 4. Calls the provided callback to determine the registry status and rotation actions
+   * 5. Inserts/updates the registry with the determined status
+   * 6. Marks older entities as OBSOLETE
+   * 7. Updates the fallback entity's status
+   *
+   * @param params.bundleUpdate - The bundle status update to apply (entityId, platform, isLods, status)
+   * @param params.versionUpdate - Optional version and build date update
+   * @param params.determineStatusAndRotate - Callback that receives the current entity and related registries,
+   *   and returns the status, older entity IDs to mark as OBSOLETE, and an optional fallback update
+   * @returns The persisted registry entity with its final status, or null if the entity was not found
+   */
+  async function persistRegistryInTransaction(params: {
+    bundleUpdate: { entityId: string; platform: string; isLods: boolean; status: Registry.SimplifiedStatus }
+    versionUpdate?: { entityId: string; platform: string; version: string; buildDate: string }
+    determineStatusAndRotate: (
+      currentEntity: Registry.DbEntity,
+      relatedRegistries: Registry.PartialDbEntity[]
+    ) => {
+      status: Registry.Status
+      olderEntityIds: string[]
+      fallbackUpdate: { id: string; status: Registry.Status } | null
+    }
+  }): Promise<Registry.DbEntity | null> {
+    return pg.withTransaction(async (client) => {
+      const { bundleUpdate, versionUpdate, determineStatusAndRotate } = params
+
+      // 1. Update the bundle status
+      let entity = await _upsertRegistryBundle(
+        bundleUpdate.entityId,
+        bundleUpdate.platform,
+        bundleUpdate.isLods,
+        bundleUpdate.status,
+        client
+      )
+
+      if (!entity) {
+        return null
+      }
+
+      // 2. Optionally update version
+      if (versionUpdate) {
+        entity = await _updateRegistryVersionWithBuildDate(
+          versionUpdate.entityId,
+          versionUpdate.platform,
+          versionUpdate.version,
+          versionUpdate.buildDate,
+          client
+        )
+
+        if (!entity) {
+          return null
+        }
+      }
+
+      // 3. Read related registries (within the same transaction for consistency)
+      const relatedRegistries = await _getRelatedRegistries(entity, client)
+
+      // 4. Let the caller determine status and rotation
+      const { status, olderEntityIds, fallbackUpdate } = determineStatusAndRotate(entity, relatedRegistries)
+
+      // 5. Insert/update the registry with the determined status
+      const insertedRegistry = await _insertRegistry({ ...entity, status }, client)
+
+      // 6. Update older entities
+      if (olderEntityIds.length > 0) {
+        await _updateRegistriesStatus(olderEntityIds, Registry.Status.OBSOLETE, client)
+      }
+
+      // 7. Update fallback
+      if (fallbackUpdate) {
+        await _updateRegistriesStatus([fallbackUpdate.id], fallbackUpdate.status, client)
+      }
+
+      return insertedRegistry
+    })
+  }
+
   return {
     insertRegistry,
     updateRegistriesStatus,
@@ -1210,6 +1508,7 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     setSpawnCoordinate,
     recalculateSpawnCoordinate,
     undeployWorldScenes,
-    undeployWorldByName
+    undeployWorldByName,
+    persistRegistryInTransaction
   }
 }

--- a/src/logic/handlers/textures-handler.ts
+++ b/src/logic/handlers/textures-handler.ts
@@ -117,57 +117,89 @@ export const createTexturesEventHandler = ({
           preservingPreviousStatus: String(shouldPreservePreviousStatus)
         })
 
-        let registryEntity: Registry.DbEntity | null = await db.upsertRegistryBundle(
-          eventMetadata.entityId,
-          eventMetadata.platform,
-          !!eventMetadata.isLods,
-          status
-        )
-
-        if (!registryEntity) {
-          logger.error('Error storing bundle', {
-            entityId: event.metadata.entityId,
-            platform: event.metadata.platform
-          })
-          return {
-            ok: false,
-            errors: ['Error storing bundle'],
-            handlerName: HANDLER_NAME
-          }
-        }
-
-        // Update version separately - but only if we're not preserving previous status
-        // If we're preserving the previous COMPLETE status, we should also keep the old version
-        // to avoid pointing clients to bundles that don't exist
-        if (!shouldPreservePreviousStatus) {
-          registryEntity = await db.updateRegistryVersionWithBuildDate(
-            event.metadata.entityId,
-            event.metadata.platform,
-            event.metadata.version,
-            new Date(event.timestamp).toISOString()
+        if (wasOriginallyObsolete) {
+          // For OBSOLETE entities, update bundles/versions without status rotation
+          let registryEntity: Registry.DbEntity | null = await db.upsertRegistryBundle(
+            eventMetadata.entityId,
+            eventMetadata.platform,
+            !!eventMetadata.isLods,
+            status
           )
 
           if (!registryEntity) {
-            logger.error('Error updating version', {
+            logger.error('Error storing bundle', {
               entityId: event.metadata.entityId,
               platform: event.metadata.platform
             })
             return {
               ok: false,
-              errors: ['Error storing version'],
+              errors: ['Error storing bundle'],
               handlerName: HANDLER_NAME
             }
           }
-        }
 
-        logger.info(`Bundle stored`, {
-          entityId: event.metadata.entityId,
-          bundles: JSON.stringify(registryEntity.bundles)
-        })
+          if (!shouldPreservePreviousStatus) {
+            registryEntity = await db.updateRegistryVersionWithBuildDate(
+              event.metadata.entityId,
+              event.metadata.platform,
+              event.metadata.version,
+              new Date(event.timestamp).toISOString()
+            )
 
-        // Skip status rotation for OBSOLETE entities - their status should be preserved
-        if (!wasOriginallyObsolete) {
-          const updatedRegistry = await registry.persistAndRotateStates(registryEntity)
+            if (!registryEntity) {
+              logger.error('Error updating version', {
+                entityId: event.metadata.entityId,
+                platform: event.metadata.platform
+              })
+              return {
+                ok: false,
+                errors: ['Error storing version'],
+                handlerName: HANDLER_NAME
+              }
+            }
+          }
+
+          logger.info('Entity was OBSOLETE, skipping status rotation', { entityId: eventMetadata.entityId })
+          logger.info('Bundle stored', {
+            entityId: event.metadata.entityId,
+            bundles: JSON.stringify(registryEntity.bundles)
+          })
+        } else {
+          // Atomically update bundle, determine status from current DB state, and rotate
+          const updatedRegistry = await registry.updateBundleAndRotateStates({
+            bundleUpdate: {
+              entityId: eventMetadata.entityId,
+              platform: eventMetadata.platform,
+              isLods: !!eventMetadata.isLods,
+              status
+            },
+            versionUpdate: !shouldPreservePreviousStatus
+              ? {
+                  entityId: eventMetadata.entityId,
+                  platform: eventMetadata.platform,
+                  version: event.metadata.version,
+                  buildDate: new Date(event.timestamp).toISOString()
+                }
+              : undefined
+          })
+
+          if (!updatedRegistry) {
+            logger.error('Error storing bundle', {
+              entityId: event.metadata.entityId,
+              platform: event.metadata.platform
+            })
+            return {
+              ok: false,
+              errors: ['Error storing bundle'],
+              handlerName: HANDLER_NAME
+            }
+          }
+
+          logger.info('Bundle stored', {
+            entityId: event.metadata.entityId,
+            bundles: JSON.stringify(updatedRegistry.bundles)
+          })
+
           // If this is a world entity and it's now processed (COMPLETE or FALLBACK),
           // trigger spawn coordinate recalculation using event timestamp for conflict resolution
           if (
@@ -176,7 +208,6 @@ export const createTexturesEventHandler = ({
           ) {
             const worldName = (updatedRegistry.metadata as any)?.worldConfiguration?.name
             if (worldName) {
-              // Extract base coordinate from entity metadata for first deployment
               const base = (updatedRegistry.metadata as any)?.scene?.base
               const firstPointer = updatedRegistry.pointers?.[0]
               const entityBaseCoordinate = base || firstPointer || null
@@ -191,7 +222,6 @@ export const createTexturesEventHandler = ({
               try {
                 await coordinates.recalculateSpawnIfNeeded(worldName, event.timestamp, entityBaseCoordinate)
               } catch (spawnError: any) {
-                // Log but don't fail the handler - spawn coordinate update is secondary
                 logger.error('Failed to recalculate spawn coordinate', {
                   worldName,
                   eventTimestamp: event.timestamp,
@@ -200,8 +230,6 @@ export const createTexturesEventHandler = ({
               }
             }
           }
-        } else {
-          logger.info('Entity was OBSOLETE, skipping status rotation', { entityId: eventMetadata.entityId })
         }
         return { ok: true, handlerName: HANDLER_NAME }
       } catch (errors: any) {

--- a/src/logic/registry/component.ts
+++ b/src/logic/registry/component.ts
@@ -9,6 +9,20 @@ export interface IRegistryComponent {
   persistAndRotateStates(registry: Omit<Registry.DbEntity, 'status'>): Promise<Registry.DbEntity>
 
   /**
+   * Atomically updates a bundle, determines status from the current DB state, and rotates related registries.
+   * All operations happen within a single database transaction to prevent race conditions from
+   * concurrent texture events overwriting correct statuses with stale data.
+   *
+   * @param params.bundleUpdate - The bundle status update to apply
+   * @param params.versionUpdate - Optional version info update
+   * @returns The updated registry entity, or null if the entity was not found
+   */
+  updateBundleAndRotateStates(params: {
+    bundleUpdate: { entityId: string; platform: string; isLods: boolean; status: Registry.SimplifiedStatus }
+    versionUpdate?: { entityId: string; platform: string; version: string; buildDate: string }
+  }): Promise<Registry.DbEntity | null>
+
+  /**
    * Undeploys world scenes and recalculates spawn coordinates.
    * Operations are performed in separate transactions with timestamp-based conflict resolution.
    *
@@ -187,8 +201,63 @@ export function createRegistryComponent({
     return result
   }
 
+  /**
+   * Atomically updates a bundle, determines the registry status from the current DB state,
+   * and rotates related registries — all within a single database transaction.
+   *
+   * This method prevents race conditions from concurrent texture events. Without atomicity,
+   * two concurrent SQS consumers processing different platform conversions for the same entity
+   * could interleave their reads and writes, causing a stale thread to overwrite a correct
+   * COMPLETE status back to PENDING. By reading the entity's current bundle state inside the
+   * transaction (after the bundle update), the status determination always reflects the latest data.
+   *
+   * @param params.bundleUpdate - The bundle status update to apply (entityId, platform, isLods, status)
+   * @param params.versionUpdate - Optional version and build date update (omitted when preserving previous status)
+   * @returns The updated registry entity with its final status, or null if the entity was not found
+   */
+  async function updateBundleAndRotateStates(params: {
+    bundleUpdate: { entityId: string; platform: string; isLods: boolean; status: Registry.SimplifiedStatus }
+    versionUpdate?: { entityId: string; platform: string; version: string; buildDate: string }
+  }): Promise<Registry.DbEntity | null> {
+    const result = await db.persistRegistryInTransaction({
+      ...params,
+      determineStatusAndRotate: (currentEntity, relatedRegistries) => {
+        const splitRelatedEntities = categorizeRelatedEntities(relatedRegistries, currentEntity)
+        const status = determineRegistryStatus(currentEntity, splitRelatedEntities)
+
+        logger.info('Persisting entity (atomic)', {
+          entityId: currentEntity.id,
+          status,
+          newerEntities: splitRelatedEntities.newerEntities?.map((e) => e.id).join(', ') || '',
+          olderEntities: splitRelatedEntities.olderEntities?.map((e) => e.id).join(', ') || '',
+          fallback: splitRelatedEntities.fallback?.id || ''
+        })
+
+        const olderEntityIds = splitRelatedEntities.olderEntities.map((e) => e.id)
+
+        let fallbackUpdate: { id: string; status: Registry.Status } | null = null
+        if (splitRelatedEntities.fallback) {
+          fallbackUpdate = {
+            id: splitRelatedEntities.fallback.id,
+            status:
+              status === Registry.Status.OBSOLETE || status === Registry.Status.COMPLETE
+                ? Registry.Status.OBSOLETE
+                : Registry.Status.FALLBACK
+          }
+        }
+
+        status === Registry.Status.COMPLETE && metrics.increment('registries_ready_count', {}, 1)
+
+        return { status, olderEntityIds, fallbackUpdate }
+      }
+    })
+
+    return result
+  }
+
   return {
     persistAndRotateStates,
+    updateBundleAndRotateStates,
     undeployWorldScenes,
     undeployWorld
   }

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -160,6 +160,25 @@ export interface IDbComponent {
   ): Promise<void>
   undeployWorldScenes(entityIds: string[], eventTimestamp: number): Promise<UndeploymentResult>
   undeployWorldByName(worldName: string, eventTimestamp: number): Promise<UndeploymentResult>
+  /**
+   * Atomically updates a bundle, optionally updates the version, reads the current entity state,
+   * reads related registries, and persists the registry with rotated statuses — all within a single transaction.
+   *
+   * This prevents race conditions where concurrent texture events could overwrite a COMPLETE status
+   * with stale PENDING data.
+   */
+  persistRegistryInTransaction(params: {
+    bundleUpdate: { entityId: string; platform: string; isLods: boolean; status: Registry.SimplifiedStatus }
+    versionUpdate?: { entityId: string; platform: string; version: string; buildDate: string }
+    determineStatusAndRotate: (
+      currentEntity: Registry.DbEntity,
+      relatedRegistries: Registry.PartialDbEntity[]
+    ) => {
+      status: Registry.Status
+      olderEntityIds: string[]
+      fallbackUpdate: { id: string; status: Registry.Status } | null
+    }
+  }): Promise<Registry.DbEntity | null>
 }
 
 export { IQueueComponent }

--- a/test/integration/texture-conversion.spec.ts
+++ b/test/integration/texture-conversion.spec.ts
@@ -1,0 +1,282 @@
+import { AssetBundleConversionFinishedEvent, Entity, EntityType, Events } from '@dcl/schemas'
+import { AuthLinkType } from '@dcl/crypto'
+import { DeploymentToSqs } from '@dcl/schemas/dist/misc/deployments-to-sqs'
+import { Registry } from '../../src/types'
+import { ManifestStatusCode } from '../../src/logic/entity-status-fetcher'
+import { getIdentity, Identity } from '../utils'
+import { test } from '../components'
+
+/**
+ * Integration tests for texture conversion event handling.
+ *
+ * These tests verify the full flow: deployment → texture conversion events → status rotation,
+ * including the atomic transaction that prevents race conditions from concurrent texture events.
+ */
+test('texture conversion handling', async ({ components, spyComponents }) => {
+  let identity: Identity
+  const registriesToCleanUp: string[] = []
+
+  beforeAll(async () => {
+    identity = await getIdentity()
+  })
+
+  afterEach(async () => {
+    if (registriesToCleanUp.length > 0) {
+      await components.db.deleteRegistries(registriesToCleanUp)
+      registriesToCleanUp.length = 0
+    }
+  })
+
+  afterAll(async () => {
+    await components.extendedDb.close()
+  })
+
+  const createDeploymentMessage = (entityId: string, contentServerUrls?: string[]): DeploymentToSqs => ({
+    entity: {
+      entityId,
+      authChain: [
+        {
+          type: AuthLinkType.SIGNER,
+          payload: identity.realAccount.address,
+          signature: ''
+        }
+      ]
+    },
+    contentServerUrls
+  })
+
+  const createEntity = (overrides: Partial<Entity> = {}): Entity => ({
+    id: 'default-entity-id',
+    version: '1',
+    type: EntityType.SCENE,
+    pointers: ['0,0'],
+    timestamp: Date.now(),
+    content: [],
+    metadata: {},
+    ...overrides
+  })
+
+  const createTextureEvent = (
+    entityId: string,
+    platform: 'windows' | 'mac',
+    overrides: Partial<AssetBundleConversionFinishedEvent> = {}
+  ): AssetBundleConversionFinishedEvent => ({
+    metadata: {
+      entityId,
+      platform,
+      statusCode: ManifestStatusCode.SUCCESS,
+      isLods: false,
+      isWorld: false,
+      version: 'v1',
+      ...overrides.metadata
+    },
+    type: Events.Type.ASSET_BUNDLE,
+    subType: Events.SubType.AssetBundle.CONVERTED,
+    key: entityId,
+    timestamp: Date.now(),
+    ...overrides
+  })
+
+  const mockGenesisCityDeployment = (entity: Entity): void => {
+    spyComponents.worlds.isWorldDeployment.mockReturnValue(false)
+    spyComponents.catalyst.getEntityById.mockResolvedValue(entity)
+  }
+
+  describe('when both platform texture conversions complete for a scene', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = `texture-both-complete-${Date.now()}`
+      const entity = createEntity({ id: entityId, pointers: ['900,900'], timestamp: 1000 })
+      mockGenesisCityDeployment(entity)
+
+      registriesToCleanUp.push(entityId)
+      await components.messageProcessor.process(createDeploymentMessage(entityId))
+
+      // Process windows conversion
+      await components.messageProcessor.process(createTextureEvent(entityId, 'windows'))
+      // Process mac conversion
+      await components.messageProcessor.process(createTextureEvent(entityId, 'mac'))
+    })
+
+    it('should mark the registry as complete', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+
+      expect(registry).not.toBeNull()
+      expect(registry!.status).toBe(Registry.Status.COMPLETE)
+    })
+
+    it('should have both platform bundles as complete', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+
+      expect(registry!.bundles.assets.windows).toBe(Registry.SimplifiedStatus.COMPLETE)
+      expect(registry!.bundles.assets.mac).toBe(Registry.SimplifiedStatus.COMPLETE)
+    })
+  })
+
+  describe('when one platform conversion fails', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = `texture-one-failed-${Date.now()}`
+      const entity = createEntity({ id: entityId, pointers: ['901,901'], timestamp: 1000 })
+      mockGenesisCityDeployment(entity)
+
+      registriesToCleanUp.push(entityId)
+      await components.messageProcessor.process(createDeploymentMessage(entityId))
+
+      // Windows succeeds
+      await components.messageProcessor.process(createTextureEvent(entityId, 'windows'))
+      // Mac fails
+      await components.messageProcessor.process(
+        createTextureEvent(entityId, 'mac', {
+          metadata: {
+            entityId,
+            platform: 'mac',
+            statusCode: ManifestStatusCode.ASSET_BUNDLE_BUILD_FAIL,
+            isLods: false,
+            isWorld: false,
+            version: 'v1'
+          }
+        })
+      )
+    })
+
+    it('should mark the registry as failed', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+
+      expect(registry).not.toBeNull()
+      expect(registry!.status).toBe(Registry.Status.FAILED)
+    })
+  })
+
+  describe('when a newer scene fails and an older complete scene exists at the same pointers', () => {
+    let olderEntityId: string
+    let newerEntityId: string
+
+    beforeEach(async () => {
+      olderEntityId = `texture-fallback-older-${Date.now()}`
+      newerEntityId = `texture-fallback-newer-${Date.now()}`
+
+      // Deploy and complete the older scene
+      const olderEntity = createEntity({ id: olderEntityId, pointers: ['902,902'], timestamp: 1000 })
+      mockGenesisCityDeployment(olderEntity)
+      registriesToCleanUp.push(olderEntityId)
+      await components.messageProcessor.process(createDeploymentMessage(olderEntityId))
+      await components.messageProcessor.process(createTextureEvent(olderEntityId, 'windows'))
+      await components.messageProcessor.process(createTextureEvent(olderEntityId, 'mac'))
+
+      // Deploy the newer scene at the same pointers
+      const newerEntity = createEntity({ id: newerEntityId, pointers: ['902,902'], timestamp: 2000 })
+      mockGenesisCityDeployment(newerEntity)
+      registriesToCleanUp.push(newerEntityId)
+      await components.messageProcessor.process(createDeploymentMessage(newerEntityId))
+
+      // Newer scene fails on mac
+      await components.messageProcessor.process(createTextureEvent(newerEntityId, 'windows'))
+      await components.messageProcessor.process(
+        createTextureEvent(newerEntityId, 'mac', {
+          metadata: {
+            entityId: newerEntityId,
+            platform: 'mac',
+            statusCode: ManifestStatusCode.ASSET_BUNDLE_BUILD_FAIL,
+            isLods: false,
+            isWorld: false,
+            version: 'v1'
+          }
+        })
+      )
+    })
+
+    it('should mark the newer registry as failed', async () => {
+      const newerRegistry = await components.db.getRegistryById(newerEntityId)
+
+      expect(newerRegistry).not.toBeNull()
+      expect(newerRegistry!.status).toBe(Registry.Status.FAILED)
+    })
+
+    it('should preserve the older registry as fallback', async () => {
+      const olderRegistry = await components.db.getRegistryById(olderEntityId)
+
+      expect(olderRegistry).not.toBeNull()
+      expect(olderRegistry!.status).toBe(Registry.Status.FALLBACK)
+    })
+  })
+
+  describe('when concurrent texture events are processed for the same entity', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = `texture-concurrent-${Date.now()}`
+      const entity = createEntity({ id: entityId, pointers: ['903,903'], timestamp: 1000 })
+      mockGenesisCityDeployment(entity)
+
+      registriesToCleanUp.push(entityId)
+      await components.messageProcessor.process(createDeploymentMessage(entityId))
+
+      // Process both platform conversions concurrently
+      await Promise.all([
+        components.messageProcessor.process(createTextureEvent(entityId, 'windows')),
+        components.messageProcessor.process(createTextureEvent(entityId, 'mac'))
+      ])
+    })
+
+    it('should mark the registry as complete', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+
+      expect(registry).not.toBeNull()
+      expect(registry!.status).toBe(Registry.Status.COMPLETE)
+    })
+
+    it('should have both platform bundles as complete', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+
+      expect(registry!.bundles.assets.windows).toBe(Registry.SimplifiedStatus.COMPLETE)
+      expect(registry!.bundles.assets.mac).toBe(Registry.SimplifiedStatus.COMPLETE)
+    })
+  })
+
+  describe('when concurrent texture events are processed and there is a fallback scene', () => {
+    let olderEntityId: string
+    let newerEntityId: string
+
+    beforeEach(async () => {
+      olderEntityId = `texture-concurrent-fallback-older-${Date.now()}`
+      newerEntityId = `texture-concurrent-fallback-newer-${Date.now()}`
+
+      // Deploy and complete the older scene
+      const olderEntity = createEntity({ id: olderEntityId, pointers: ['904,904'], timestamp: 1000 })
+      mockGenesisCityDeployment(olderEntity)
+      registriesToCleanUp.push(olderEntityId)
+      await components.messageProcessor.process(createDeploymentMessage(olderEntityId))
+      await components.messageProcessor.process(createTextureEvent(olderEntityId, 'windows'))
+      await components.messageProcessor.process(createTextureEvent(olderEntityId, 'mac'))
+
+      // Deploy the newer scene at the same pointers
+      const newerEntity = createEntity({ id: newerEntityId, pointers: ['904,904'], timestamp: 2000 })
+      mockGenesisCityDeployment(newerEntity)
+      registriesToCleanUp.push(newerEntityId)
+      await components.messageProcessor.process(createDeploymentMessage(newerEntityId))
+
+      // Process both platform conversions concurrently for the newer scene
+      await Promise.all([
+        components.messageProcessor.process(createTextureEvent(newerEntityId, 'windows')),
+        components.messageProcessor.process(createTextureEvent(newerEntityId, 'mac'))
+      ])
+    })
+
+    it('should mark the newer registry as complete', async () => {
+      const newerRegistry = await components.db.getRegistryById(newerEntityId)
+
+      expect(newerRegistry).not.toBeNull()
+      expect(newerRegistry!.status).toBe(Registry.Status.COMPLETE)
+    })
+
+    it('should mark the older registry as obsolete since the newer one is complete', async () => {
+      const olderRegistry = await components.db.getRegistryById(olderEntityId)
+
+      expect(olderRegistry).not.toBeNull()
+      expect(olderRegistry!.status).toBe(Registry.Status.OBSOLETE)
+    })
+  })
+})

--- a/test/unit/logic/handlers/textures-handler.spec.ts
+++ b/test/unit/logic/handlers/textures-handler.spec.ts
@@ -129,33 +129,27 @@ describe('textures-handler', () => {
         catalyst.getEntityById = jest.fn().mockResolvedValue(entity)
         // persistAndRotateStates must return the created entity so we can access bundles later
         registry.persistAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
-        db.upsertRegistryBundle = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        db.updateRegistryVersionWithBuildDate = jest.fn().mockResolvedValue(dbEntity)
+        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(true)
-        expect(registry.persistAndRotateStates).toHaveBeenCalledWith(dbEntity)
-        expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-          '123',
-          'windows',
-          'v1',
-          new Date(event.timestamp).toISOString()
-        )
+        const { status: _status, ...dbEntityWithoutStatus } = dbEntity
+        expect(registry.persistAndRotateStates).toHaveBeenCalledWith(dbEntityWithoutStatus)
+        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+          bundleUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            isLods: false,
+            status: Registry.SimplifiedStatus.COMPLETE
+          },
+          versionUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            version: 'v1',
+            buildDate: new Date(event.timestamp).toISOString()
+          }
+        })
       })
 
       it('should create entity with default bundle status when fetched from worlds', async () => {
@@ -176,42 +170,26 @@ describe('textures-handler', () => {
         worlds.getWorld = jest.fn().mockResolvedValue(entity)
         // persistAndRotateStates must return the created entity so we can access bundles later
         registry.persistAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
-        db.upsertRegistryBundle = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        db.updateRegistryVersionWithBuildDate = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          versions: {
-            assets: {
-              windows: { version: 'v1', buildDate: '2024-01-01' },
-              mac: { version: '', buildDate: '' },
-              webgl: { version: '', buildDate: '' }
-            }
-          }
-        })
+        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(true)
         expect(worlds.getWorld).toHaveBeenCalledWith(event.metadata.entityId)
-        expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-          '123',
-          'windows',
-          'v1',
-          new Date(event.timestamp).toISOString()
-        )
+        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+          bundleUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            isLods: false,
+            status: Registry.SimplifiedStatus.COMPLETE
+          },
+          versionUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            version: 'v1',
+            buildDate: new Date(event.timestamp).toISOString()
+          }
+        })
       })
 
       it('should return error when entity not found in catalyst or worlds', async () => {
@@ -273,41 +251,25 @@ describe('textures-handler', () => {
         const entity = createEntity()
         const dbEntity = createDbEntity(entity)
         db.getRegistryById = jest.fn().mockResolvedValue(dbEntity)
-        db.upsertRegistryBundle = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        db.updateRegistryVersionWithBuildDate = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          versions: {
-            assets: {
-              windows: { version: 'v1', buildDate: '2024-01-01' },
-              mac: { version: '', buildDate: '' },
-              webgl: { version: '', buildDate: '' }
-            }
-          }
-        })
+        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(true)
-        expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-          '123',
-          'windows',
-          'v1',
-          new Date(event.timestamp).toISOString()
-        )
+        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+          bundleUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            isLods: false,
+            status: Registry.SimplifiedStatus.COMPLETE
+          },
+          versionUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            version: 'v1',
+            buildDate: new Date(event.timestamp).toISOString()
+          }
+        })
       })
 
       it('should update bundle status for mac platform with tolerated errors', async () => {
@@ -324,41 +286,25 @@ describe('textures-handler', () => {
         const entity = createEntity()
         const dbEntity = createDbEntity(entity)
         db.getRegistryById = jest.fn().mockResolvedValue(dbEntity)
-        db.upsertRegistryBundle = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.COMPLETE,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        db.updateRegistryVersionWithBuildDate = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          versions: {
-            assets: {
-              windows: { version: '', buildDate: '' },
-              mac: { version: 'v1', buildDate: '2024-01-01' },
-              webgl: { version: '', buildDate: '' }
-            }
-          }
-        })
+        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(true)
-        expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-          '123',
-          'mac',
-          'v1',
-          new Date(event.timestamp).toISOString()
-        )
+        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+          bundleUpdate: {
+            entityId: '123',
+            platform: 'mac',
+            isLods: false,
+            status: Registry.SimplifiedStatus.COMPLETE
+          },
+          versionUpdate: {
+            entityId: '123',
+            platform: 'mac',
+            version: 'v1',
+            buildDate: new Date(event.timestamp).toISOString()
+          }
+        })
       })
 
       it('should update bundle status for webgl platform with already converted status', async () => {
@@ -375,41 +321,25 @@ describe('textures-handler', () => {
         const entity = createEntity()
         const dbEntity = createDbEntity(entity)
         db.getRegistryById = jest.fn().mockResolvedValue(dbEntity)
-        db.upsertRegistryBundle = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.COMPLETE
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        db.updateRegistryVersionWithBuildDate = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          versions: {
-            assets: {
-              windows: { version: '', buildDate: '' },
-              mac: { version: '', buildDate: '' },
-              webgl: { version: 'v1', buildDate: '2024-01-01' }
-            }
-          }
-        })
+        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(true)
-        expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-          '123',
-          'webgl',
-          'v1',
-          new Date(event.timestamp).toISOString()
-        )
+        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+          bundleUpdate: {
+            entityId: '123',
+            platform: 'webgl',
+            isLods: false,
+            status: Registry.SimplifiedStatus.COMPLETE
+          },
+          versionUpdate: {
+            entityId: '123',
+            platform: 'webgl',
+            version: 'v1',
+            buildDate: new Date(event.timestamp).toISOString()
+          }
+        })
       })
 
       it('should mark bundle as failed when conversion fails and entity had PENDING status', async () => {
@@ -426,42 +356,25 @@ describe('textures-handler', () => {
         const entity = createEntity()
         const dbEntity = createDbEntity(entity)
         db.getRegistryById = jest.fn().mockResolvedValue(dbEntity)
-        db.upsertRegistryBundle = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.FAILED,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        db.updateRegistryVersionWithBuildDate = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          versions: {
-            assets: {
-              windows: { version: 'v1', buildDate: '2024-01-01' },
-              mac: { version: '', buildDate: '' },
-              webgl: { version: '', buildDate: '' }
-            }
-          }
-        })
+        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(true)
-        expect(db.upsertRegistryBundle).toHaveBeenCalledWith('123', 'windows', false, Registry.SimplifiedStatus.FAILED)
-        expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-          '123',
-          'windows',
-          'v1',
-          new Date(event.timestamp).toISOString()
-        )
+        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+          bundleUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            isLods: false,
+            status: Registry.SimplifiedStatus.FAILED
+          },
+          versionUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            version: 'v1',
+            buildDate: new Date(event.timestamp).toISOString()
+          }
+        })
       })
 
       describe('and reconversion fails', () => {
@@ -505,7 +418,7 @@ describe('textures-handler', () => {
               }
             }
             db.getRegistryById = jest.fn().mockResolvedValue(dbEntityWithCompleteBundles)
-            db.upsertRegistryBundle = jest.fn().mockResolvedValue(dbEntityWithCompleteBundles)
+            registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntityWithCompleteBundles)
 
             result = await handler.handle(event)
           })
@@ -515,12 +428,15 @@ describe('textures-handler', () => {
           })
 
           it('should preserve COMPLETE status instead of marking as FAILED', () => {
-            expect(db.upsertRegistryBundle).toHaveBeenCalledWith(
-              '123',
-              'windows',
-              false,
-              Registry.SimplifiedStatus.COMPLETE
-            )
+            expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+              bundleUpdate: {
+                entityId: '123',
+                platform: 'windows',
+                isLods: false,
+                status: Registry.SimplifiedStatus.COMPLETE
+              },
+              versionUpdate: undefined
+            })
           })
 
           it('should not update the version to avoid pointing to non-existent bundles', () => {
@@ -528,7 +444,7 @@ describe('textures-handler', () => {
           })
 
           it('should still rotate the registry states', () => {
-            expect(registry.persistAndRotateStates).toHaveBeenCalledWith(dbEntityWithCompleteBundles)
+            expect(registry.updateBundleAndRotateStates).toHaveBeenCalled()
           })
         })
 
@@ -565,7 +481,7 @@ describe('textures-handler', () => {
               }
             }
             db.getRegistryById = jest.fn().mockResolvedValue(dbEntityWithCompleteLods)
-            db.upsertRegistryBundle = jest.fn().mockResolvedValue(dbEntityWithCompleteLods)
+            registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntityWithCompleteLods)
 
             result = await handler.handle(event)
           })
@@ -575,7 +491,15 @@ describe('textures-handler', () => {
           })
 
           it('should preserve COMPLETE status for LODs', () => {
-            expect(db.upsertRegistryBundle).toHaveBeenCalledWith('123', 'mac', true, Registry.SimplifiedStatus.COMPLETE)
+            expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+              bundleUpdate: {
+                entityId: '123',
+                platform: 'mac',
+                isLods: true,
+                status: Registry.SimplifiedStatus.COMPLETE
+              },
+              versionUpdate: undefined
+            })
           })
 
           it('should not update the version', () => {
@@ -636,8 +560,7 @@ describe('textures-handler', () => {
               }
             }
             db.getRegistryById = jest.fn().mockResolvedValue(dbEntityWithCompleteBundles)
-            db.upsertRegistryBundle = jest.fn().mockResolvedValue(dbEntityWithCompleteBundles)
-            db.updateRegistryVersionWithBuildDate = jest.fn().mockResolvedValue(updatedDbEntity)
+            registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(updatedDbEntity)
 
             result = await handler.handle(event)
           })
@@ -647,25 +570,37 @@ describe('textures-handler', () => {
           })
 
           it('should update bundle status to COMPLETE', () => {
-            expect(db.upsertRegistryBundle).toHaveBeenCalledWith(
-              '123',
-              'windows',
-              false,
-              Registry.SimplifiedStatus.COMPLETE
-            )
+            expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+              bundleUpdate: {
+                entityId: '123',
+                platform: 'windows',
+                isLods: false,
+                status: Registry.SimplifiedStatus.COMPLETE
+              },
+              versionUpdate: {
+                entityId: '123',
+                platform: 'windows',
+                version: 'v2',
+                buildDate: new Date(event.timestamp).toISOString()
+              }
+            })
           })
 
           it('should update version to the new version', () => {
-            expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-              '123',
-              'windows',
-              'v2',
-              new Date(event.timestamp).toISOString()
+            expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith(
+              expect.objectContaining({
+                versionUpdate: {
+                  entityId: '123',
+                  platform: 'windows',
+                  version: 'v2',
+                  buildDate: new Date(event.timestamp).toISOString()
+                }
+              })
             )
           })
 
           it('should rotate the registry states with the updated entity', () => {
-            expect(registry.persistAndRotateStates).toHaveBeenCalledWith(updatedDbEntity)
+            expect(registry.updateBundleAndRotateStates).toHaveBeenCalled()
           })
         })
       })
@@ -684,41 +619,25 @@ describe('textures-handler', () => {
         const entity = createEntity()
         const dbEntity = createDbEntity(entity)
         db.getRegistryById = jest.fn().mockResolvedValue(dbEntity)
-        db.upsertRegistryBundle = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        db.updateRegistryVersionWithBuildDate = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          versions: {
-            assets: {
-              windows: { version: 'v1', buildDate: '2024-01-01' },
-              mac: { version: '', buildDate: '' },
-              webgl: { version: '', buildDate: '' }
-            }
-          }
-        })
+        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(true)
-        expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-          '123',
-          'windows',
-          'v1',
-          new Date(event.timestamp).toISOString()
-        )
+        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+          bundleUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            isLods: true,
+            status: Registry.SimplifiedStatus.COMPLETE
+          },
+          versionUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            version: 'v1',
+            buildDate: new Date(event.timestamp).toISOString()
+          }
+        })
       })
 
       it('should return error when upsert fails', async () => {
@@ -726,7 +645,7 @@ describe('textures-handler', () => {
         const entity = createEntity()
         const dbEntity = createDbEntity(entity)
         db.getRegistryById = jest.fn().mockResolvedValue(dbEntity)
-        db.upsertRegistryBundle = jest.fn().mockResolvedValue(null)
+        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(null)
 
         const result = await handler.handle(event)
 
@@ -739,27 +658,12 @@ describe('textures-handler', () => {
         const entity = createEntity()
         const dbEntity = createDbEntity(entity)
         db.getRegistryById = jest.fn().mockResolvedValue(dbEntity)
-        db.upsertRegistryBundle = jest.fn().mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        db.updateRegistryVersionWithBuildDate = jest.fn().mockResolvedValue(null)
+        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(null)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(false)
-        expect(result.errors).toEqual(['Error storing version'])
+        expect(result.errors).toEqual(['Error storing bundle'])
       })
 
       describe('and the entity is OBSOLETE', () => {
@@ -845,41 +749,25 @@ describe('textures-handler', () => {
         const entity = createEntity()
         const dbEntity = createDbEntity(entity)
         ;(db.getRegistryById as jest.Mock).mockResolvedValue(dbEntity)
-        ;(db.upsertRegistryBundle as jest.Mock).mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        ;(db.updateRegistryVersionWithBuildDate as jest.Mock).mockResolvedValue({
-          ...dbEntity,
-          versions: {
-            assets: {
-              windows: { version: 'v1', buildDate: '2024-01-01' },
-              mac: { version: '', buildDate: '' },
-              webgl: { version: '', buildDate: '' }
-            }
-          }
-        })
+        ;(registry.updateBundleAndRotateStates as jest.Mock).mockResolvedValue(dbEntity)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(true)
-        expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-          '123',
-          'windows',
-          'v1',
-          new Date(event.timestamp).toISOString()
-        )
+        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+          bundleUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            isLods: false,
+            status: Registry.SimplifiedStatus.COMPLETE
+          },
+          versionUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            version: 'v1',
+            buildDate: new Date(event.timestamp).toISOString()
+          }
+        })
       })
 
       it('should update bundle status for lods', async () => {
@@ -896,41 +784,25 @@ describe('textures-handler', () => {
         const entity = createEntity()
         const dbEntity = createDbEntity(entity)
         ;(db.getRegistryById as jest.Mock).mockResolvedValue(dbEntity)
-        ;(db.upsertRegistryBundle as jest.Mock).mockResolvedValue({
-          ...dbEntity,
-          bundles: {
-            assets: {
-              windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            }
-          }
-        })
-        ;(db.updateRegistryVersionWithBuildDate as jest.Mock).mockResolvedValue({
-          ...dbEntity,
-          versions: {
-            assets: {
-              windows: { version: 'v1', buildDate: '' },
-              mac: { version: '', buildDate: '' },
-              webgl: { version: '', buildDate: '' }
-            }
-          }
-        })
+        ;(registry.updateBundleAndRotateStates as jest.Mock).mockResolvedValue(dbEntity)
 
         const result = await handler.handle(event)
 
         expect(result.ok).toBe(true)
-        expect(db.updateRegistryVersionWithBuildDate).toHaveBeenCalledWith(
-          '123',
-          'windows',
-          'v1',
-          new Date(event.timestamp).toISOString()
-        )
+        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+          bundleUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            isLods: true,
+            status: Registry.SimplifiedStatus.COMPLETE
+          },
+          versionUpdate: {
+            entityId: '123',
+            platform: 'windows',
+            version: 'v1',
+            buildDate: new Date(event.timestamp).toISOString()
+          }
+        })
       })
     })
   })

--- a/test/unit/logic/registry/component.spec.ts
+++ b/test/unit/logic/registry/component.spec.ts
@@ -333,6 +333,444 @@ describe('when using the registry component', () => {
     })
   })
 
+  describe('when a world scene overlaps an existing one and the new scene fails conversion', () => {
+    describe('and there are two scenes (A complete, B overlapping and failing)', () => {
+      let sceneA: Registry.DbEntity
+      let sceneB: Registry.DbEntity
+
+      beforeEach(() => {
+        sceneA = withAssetStatus(
+          createRelativeRegistry(-1000, Registry.Status.COMPLETE, 'scene-a'),
+          Registry.SimplifiedStatus.COMPLETE,
+          Registry.SimplifiedStatus.COMPLETE
+        )
+      })
+
+      it('should keep scene A as fallback when scene B is first deployed as pending', async () => {
+        sceneB = createRelativeRegistry(0, Registry.Status.PENDING, 'scene-b')
+
+        db.getRelatedRegistries.mockResolvedValue([sceneA])
+
+        await component.persistAndRotateStates(sceneB)
+
+        expect(db.insertRegistry).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'scene-b', status: Registry.Status.PENDING })
+        )
+        expect(db.updateRegistriesStatus).toHaveBeenCalledWith([sceneA.id], Registry.Status.FALLBACK)
+      })
+
+      it('should keep scene A as fallback when scene B fails conversion', async () => {
+        sceneA = createRelativeRegistry(-1000, Registry.Status.FALLBACK, 'scene-a')
+        sceneB = withAssetStatus(
+          createRelativeRegistry(0, Registry.Status.PENDING, 'scene-b'),
+          Registry.SimplifiedStatus.FAILED,
+          Registry.SimplifiedStatus.FAILED
+        )
+
+        db.getRelatedRegistries.mockResolvedValue([sceneA])
+
+        await component.persistAndRotateStates(sceneB)
+
+        expect(db.insertRegistry).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'scene-b', status: Registry.Status.FAILED })
+        )
+        expect(db.updateRegistriesStatus).toHaveBeenCalledWith([sceneA.id], Registry.Status.FALLBACK)
+      })
+
+      it('should not mark scene A as obsolete when scene B fails', async () => {
+        sceneA = createRelativeRegistry(-1000, Registry.Status.FALLBACK, 'scene-a')
+        sceneB = withAssetStatus(
+          createRelativeRegistry(0, Registry.Status.PENDING, 'scene-b'),
+          Registry.SimplifiedStatus.FAILED,
+          Registry.SimplifiedStatus.COMPLETE
+        )
+
+        db.getRelatedRegistries.mockResolvedValue([sceneA])
+
+        await component.persistAndRotateStates(sceneB)
+
+        expect(db.updateRegistriesStatus).not.toHaveBeenCalledWith([sceneA.id], Registry.Status.OBSOLETE)
+      })
+    })
+
+    describe('and there are three rapid deployments (A complete, B and C overlapping, both fail)', () => {
+      let sceneA: Registry.DbEntity
+      let sceneB: Registry.DbEntity
+      let sceneC: Registry.DbEntity
+
+      beforeEach(() => {
+        sceneA = withAssetStatus(
+          createRelativeRegistry(-2000, Registry.Status.FALLBACK, 'scene-a'),
+          Registry.SimplifiedStatus.COMPLETE,
+          Registry.SimplifiedStatus.COMPLETE
+        )
+        sceneB = createRelativeRegistry(-1000, Registry.Status.PENDING, 'scene-b')
+        sceneC = createRelativeRegistry(0, Registry.Status.PENDING, 'scene-c')
+      })
+
+      it('should keep scene A as fallback when scene C is deployed (marking scene B as obsolete)', async () => {
+        db.getRelatedRegistries.mockResolvedValue([sceneA, sceneB])
+
+        await component.persistAndRotateStates(sceneC)
+
+        expect(db.insertRegistry).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'scene-c', status: Registry.Status.PENDING })
+        )
+        expect(db.updateRegistriesStatus).toHaveBeenCalledWith(['scene-b'], Registry.Status.OBSOLETE)
+        expect(db.updateRegistriesStatus).toHaveBeenCalledWith([sceneA.id], Registry.Status.FALLBACK)
+      })
+
+      it('should keep scene A as fallback when scene C fails conversion', async () => {
+        sceneC = withAssetStatus(sceneC, Registry.SimplifiedStatus.FAILED, Registry.SimplifiedStatus.FAILED)
+
+        // Scene B is now obsolete, so only scene A appears in related registries
+        db.getRelatedRegistries.mockResolvedValue([sceneA])
+
+        await component.persistAndRotateStates(sceneC)
+
+        expect(db.insertRegistry).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'scene-c', status: Registry.Status.FAILED })
+        )
+        expect(db.updateRegistriesStatus).toHaveBeenCalledWith([sceneA.id], Registry.Status.FALLBACK)
+        expect(db.updateRegistriesStatus).not.toHaveBeenCalledWith([sceneA.id], Registry.Status.OBSOLETE)
+      })
+    })
+
+    describe('and the older scene was complete, a newer overlapping scene completes, then a third fails', () => {
+      let sceneA: Registry.DbEntity
+      let sceneB: Registry.DbEntity
+      let sceneC: Registry.DbEntity
+
+      it('should mark scene A as obsolete when scene B completes', async () => {
+        sceneA = withAssetStatus(
+          createRelativeRegistry(-2000, Registry.Status.FALLBACK, 'scene-a'),
+          Registry.SimplifiedStatus.COMPLETE,
+          Registry.SimplifiedStatus.COMPLETE
+        )
+        sceneB = withAssetStatus(
+          createRelativeRegistry(-1000, Registry.Status.PENDING, 'scene-b'),
+          Registry.SimplifiedStatus.COMPLETE,
+          Registry.SimplifiedStatus.COMPLETE
+        )
+
+        db.getRelatedRegistries.mockResolvedValue([sceneA])
+
+        await component.persistAndRotateStates(sceneB)
+
+        expect(db.insertRegistry).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'scene-b', status: Registry.Status.COMPLETE })
+        )
+        expect(db.updateRegistriesStatus).toHaveBeenCalledWith([sceneA.id], Registry.Status.OBSOLETE)
+      })
+
+      it('should keep scene B as fallback when scene C is deployed and then fails', async () => {
+        sceneB = withAssetStatus(
+          createRelativeRegistry(-1000, Registry.Status.FALLBACK, 'scene-b'),
+          Registry.SimplifiedStatus.COMPLETE,
+          Registry.SimplifiedStatus.COMPLETE
+        )
+        sceneC = withAssetStatus(
+          createRelativeRegistry(0, Registry.Status.PENDING, 'scene-c'),
+          Registry.SimplifiedStatus.FAILED,
+          Registry.SimplifiedStatus.FAILED
+        )
+
+        // Scene A is obsolete, only scene B appears in related registries
+        db.getRelatedRegistries.mockResolvedValue([sceneB])
+
+        await component.persistAndRotateStates(sceneC)
+
+        expect(db.insertRegistry).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'scene-c', status: Registry.Status.FAILED })
+        )
+        expect(db.updateRegistriesStatus).toHaveBeenCalledWith([sceneB.id], Registry.Status.FALLBACK)
+        expect(db.updateRegistriesStatus).not.toHaveBeenCalledWith([sceneB.id], Registry.Status.OBSOLETE)
+      })
+    })
+  })
+
+  describe('when concurrent texture events would have caused a race condition', () => {
+    /**
+     * This test verifies that updateBundleAndRotateStates prevents the following race condition
+     * that was possible with the old non-atomic persistAndRotateStates:
+     *
+     * 1. Scene A is COMPLETE, Scene B is deployed → A becomes FALLBACK, B is PENDING
+     * 2. B's mac and windows conversions complete concurrently (two SQS messages)
+     * 3. Thread 2 (windows) processes first:
+     *    - upsertRegistryBundle sets B.windows = COMPLETE
+     *    - RETURNING * gives B with mac=COMPLETE, windows=COMPLETE
+     *    - persistAndRotateStates → B = COMPLETE, A → OBSOLETE
+     * 4. Thread 1 (mac) processes after, but read B from DB BEFORE Thread 2's upsert:
+     *    - upsertRegistryBundle set B.mac = COMPLETE earlier
+     *    - But Thread 1's registryEntity snapshot still has windows=PENDING (stale)
+     *    - OLD BUG: persistAndRotateStates → B = PENDING (stale overwrite!)
+     *
+     * With updateBundleAndRotateStates, the status is determined from the current DB state
+     * inside a transaction AFTER the bundle update, so Thread 1 would see both platforms as
+     * COMPLETE and correctly determine B = COMPLETE.
+     */
+    it('should not overwrite scene B to pending with stale data after it was already set to complete', async () => {
+      const sceneA = withAssetStatus(
+        createRelativeRegistry(-1000, Registry.Status.FALLBACK, 'scene-a'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      // The DB transaction always reads the CURRENT entity state after updating the bundle.
+      // Even though Thread 1's caller had stale data (windows=PENDING), the transaction reads
+      // the entity AFTER upsertRegistryBundle, which reflects both mac=COMPLETE and windows=COMPLETE.
+      const sceneBCurrentDbState = withAssetStatus(
+        createRelativeRegistry(0, Registry.Status.PENDING, 'scene-b'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      db.persistRegistryInTransaction.mockImplementation(async (params) => {
+        // The transaction reads the entity's CURRENT state from DB (both platforms complete)
+        const result = params.determineStatusAndRotate(sceneBCurrentDbState, [sceneA])
+        return { ...sceneBCurrentDbState, status: result.status }
+      })
+
+      const updated = await component.updateBundleAndRotateStates({
+        bundleUpdate: {
+          entityId: 'scene-b',
+          platform: 'mac',
+          isLods: false,
+          status: Registry.SimplifiedStatus.COMPLETE
+        }
+      })
+
+      // B is correctly determined as COMPLETE from the current DB state, not PENDING from stale data
+      expect(updated!.status).not.toBe(Registry.Status.PENDING)
+      expect(updated!.status).toBe(Registry.Status.COMPLETE)
+    })
+
+    it('should not leave the world without a fallback after concurrent texture events', async () => {
+      const sceneA = withAssetStatus(
+        createRelativeRegistry(-1000, Registry.Status.FALLBACK, 'scene-a'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      // Because the transaction reads the current DB state, B's status is correctly set to COMPLETE.
+      // When Scene C is later deployed and fails, B (COMPLETE) would be demoted to FALLBACK — not OBSOLETE.
+      const sceneBComplete = withAssetStatus(
+        createRelativeRegistry(0, Registry.Status.PENDING, 'scene-b'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      let capturedResult: any = null
+      db.persistRegistryInTransaction.mockImplementation(async (params) => {
+        const result = params.determineStatusAndRotate(sceneBComplete, [sceneA])
+        capturedResult = result
+        return { ...sceneBComplete, status: result.status }
+      })
+
+      await component.updateBundleAndRotateStates({
+        bundleUpdate: {
+          entityId: 'scene-b',
+          platform: 'windows',
+          isLods: false,
+          status: Registry.SimplifiedStatus.COMPLETE
+        }
+      })
+
+      // B = COMPLETE, A's fallback is correctly marked OBSOLETE (because B successfully completed)
+      expect(capturedResult.status).toBe(Registry.Status.COMPLETE)
+      expect(capturedResult.fallbackUpdate).toEqual({
+        id: sceneA.id,
+        status: Registry.Status.OBSOLETE
+      })
+
+      // Now verify: if C is deployed and fails, B (now COMPLETE → FALLBACK) would NOT be marked OBSOLETE.
+      // The race condition would have left B as PENDING (stuck), causing it to be marked OBSOLETE
+      // when C arrived. With the fix, B is correctly COMPLETE, so it becomes FALLBACK — surviving the purger.
+      const sceneBFallback = withAssetStatus(
+        createRelativeRegistry(0, Registry.Status.FALLBACK, 'scene-b'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+      const sceneCFailed = withAssetStatus(
+        createRelativeRegistry(1000, Registry.Status.PENDING, 'scene-c'),
+        Registry.SimplifiedStatus.FAILED,
+        Registry.SimplifiedStatus.FAILED
+      )
+
+      db.persistRegistryInTransaction.mockImplementation(async (params) => {
+        const result = params.determineStatusAndRotate(sceneCFailed, [sceneBFallback])
+        capturedResult = result
+        return { ...sceneCFailed, status: result.status }
+      })
+
+      await component.updateBundleAndRotateStates({
+        bundleUpdate: {
+          entityId: 'scene-c',
+          platform: 'mac',
+          isLods: false,
+          status: Registry.SimplifiedStatus.FAILED
+        }
+      })
+
+      // C = FAILED, B stays as FALLBACK (not OBSOLETE)
+      expect(capturedResult.status).toBe(Registry.Status.FAILED)
+      expect(capturedResult.fallbackUpdate).toEqual({
+        id: sceneBFallback.id,
+        status: Registry.Status.FALLBACK
+      })
+      expect(capturedResult.olderEntityIds).not.toContain('scene-b')
+    })
+  })
+
+  describe('when using updateBundleAndRotateStates (atomic)', () => {
+    /**
+     * updateBundleAndRotateStates prevents the race condition by reading the current entity state
+     * from the DB inside a transaction AFTER updating the bundle, instead of trusting the caller's
+     * potentially stale data.
+     */
+    it('should determine status from current DB state, not stale caller data', async () => {
+      const sceneA = withAssetStatus(
+        createRelativeRegistry(-1000, Registry.Status.FALLBACK, 'scene-a'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      // Simulate what persistRegistryInTransaction does:
+      // After upsertRegistryBundle, the DB returns the entity with CURRENT bundles (both complete),
+      // regardless of what the caller's snapshot had.
+      const sceneBCurrentDbState = withAssetStatus(
+        createRelativeRegistry(0, Registry.Status.PENDING, 'scene-b'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      // The DB transaction mock calls determineStatusAndRotate with the current DB entity
+      db.persistRegistryInTransaction.mockImplementation(async (params) => {
+        const { determineStatusAndRotate } = params
+        // The transaction reads the entity's CURRENT state from DB (both platforms complete)
+        const result = determineStatusAndRotate(sceneBCurrentDbState, [sceneA])
+        return { ...sceneBCurrentDbState, status: result.status }
+      })
+
+      const updated = await component.updateBundleAndRotateStates({
+        bundleUpdate: {
+          entityId: 'scene-b',
+          platform: 'mac',
+          isLods: false,
+          status: Registry.SimplifiedStatus.COMPLETE
+        }
+      })
+
+      // The status is determined from the current DB state (both platforms complete),
+      // NOT from the caller's stale data. With scene A (FALLBACK) as the only related entity
+      // and no newer entities, B should be COMPLETE.
+      expect(updated!.status).toBe(Registry.Status.COMPLETE)
+    })
+
+    it('should correctly mark the fallback as obsolete when the entity completes', async () => {
+      const sceneA = withAssetStatus(
+        createRelativeRegistry(-1000, Registry.Status.FALLBACK, 'scene-a'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      const sceneBComplete = withAssetStatus(
+        createRelativeRegistry(0, Registry.Status.PENDING, 'scene-b'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      let capturedResult: any = null
+      db.persistRegistryInTransaction.mockImplementation(async (params) => {
+        const result = params.determineStatusAndRotate(sceneBComplete, [sceneA])
+        capturedResult = result
+        return { ...sceneBComplete, status: result.status }
+      })
+
+      await component.updateBundleAndRotateStates({
+        bundleUpdate: {
+          entityId: 'scene-b',
+          platform: 'windows',
+          isLods: false,
+          status: Registry.SimplifiedStatus.COMPLETE
+        }
+      })
+
+      expect(capturedResult.status).toBe(Registry.Status.COMPLETE)
+      expect(capturedResult.fallbackUpdate).toEqual({
+        id: sceneA.id,
+        status: Registry.Status.OBSOLETE
+      })
+    })
+
+    it('should keep the fallback when the entity fails', async () => {
+      const sceneA = withAssetStatus(
+        createRelativeRegistry(-1000, Registry.Status.FALLBACK, 'scene-a'),
+        Registry.SimplifiedStatus.COMPLETE,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      const sceneBFailed = withAssetStatus(
+        createRelativeRegistry(0, Registry.Status.PENDING, 'scene-b'),
+        Registry.SimplifiedStatus.FAILED,
+        Registry.SimplifiedStatus.COMPLETE
+      )
+
+      let capturedResult: any = null
+      db.persistRegistryInTransaction.mockImplementation(async (params) => {
+        const result = params.determineStatusAndRotate(sceneBFailed, [sceneA])
+        capturedResult = result
+        return { ...sceneBFailed, status: result.status }
+      })
+
+      await component.updateBundleAndRotateStates({
+        bundleUpdate: {
+          entityId: 'scene-b',
+          platform: 'mac',
+          isLods: false,
+          status: Registry.SimplifiedStatus.FAILED
+        }
+      })
+
+      expect(capturedResult.status).toBe(Registry.Status.FAILED)
+      expect(capturedResult.fallbackUpdate).toEqual({
+        id: sceneA.id,
+        status: Registry.Status.FALLBACK
+      })
+    })
+
+    it('should pass version update to the transaction when provided', async () => {
+      const sceneB = createRelativeRegistry(0, Registry.Status.PENDING, 'scene-b')
+
+      db.persistRegistryInTransaction.mockImplementation(async (params) => {
+        const result = params.determineStatusAndRotate(sceneB, [])
+        return { ...sceneB, status: result.status }
+      })
+
+      await component.updateBundleAndRotateStates({
+        bundleUpdate: {
+          entityId: 'scene-b',
+          platform: 'mac',
+          isLods: false,
+          status: Registry.SimplifiedStatus.COMPLETE
+        },
+        versionUpdate: {
+          entityId: 'scene-b',
+          platform: 'mac',
+          version: '1.0.0',
+          buildDate: '2026-01-01'
+        }
+      })
+
+      expect(db.persistRegistryInTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bundleUpdate: expect.objectContaining({ entityId: 'scene-b', platform: 'mac' }),
+          versionUpdate: expect.objectContaining({ version: '1.0.0', buildDate: '2026-01-01' })
+        })
+      )
+    })
+  })
+
   describe('and calling undeployWorldScenes', () => {
     let entityIds: string[]
     let eventTimestamp: number

--- a/test/unit/mocks/db.ts
+++ b/test/unit/mocks/db.ts
@@ -39,6 +39,7 @@ export function createDbMockComponent(): jest.Mocked<IDbComponent> {
     setSpawnCoordinate: jest.fn(),
     recalculateSpawnCoordinate: jest.fn(),
     undeployWorldScenes: jest.fn(),
-    undeployWorldByName: jest.fn()
+    undeployWorldByName: jest.fn(),
+    persistRegistryInTransaction: jest.fn()
   }
 }

--- a/test/unit/mocks/registry.ts
+++ b/test/unit/mocks/registry.ts
@@ -32,6 +32,35 @@ export function createRegistryMockComponent(): jest.Mocked<IRegistryComponent> {
         }
       }
     } as Registry.DbEntity),
+    updateBundleAndRotateStates: jest.fn().mockResolvedValue({
+      id: 'mock-entity-id',
+      type: 'scene',
+      timestamp: Date.now(),
+      deployer: '0x123',
+      pointers: ['0,0'],
+      content: [],
+      metadata: {},
+      status: Registry.Status.PENDING,
+      bundles: {
+        assets: {
+          windows: Registry.SimplifiedStatus.PENDING,
+          mac: Registry.SimplifiedStatus.PENDING,
+          webgl: Registry.SimplifiedStatus.PENDING
+        },
+        lods: {
+          windows: Registry.SimplifiedStatus.PENDING,
+          mac: Registry.SimplifiedStatus.PENDING,
+          webgl: Registry.SimplifiedStatus.PENDING
+        }
+      },
+      versions: {
+        assets: {
+          windows: { version: '', buildDate: '' },
+          mac: { version: '', buildDate: '' },
+          webgl: { version: '', buildDate: '' }
+        }
+      }
+    } as Registry.DbEntity),
     undeployWorldScenes: jest.fn().mockResolvedValue({
       undeployedCount: 0,
       worldName: null


### PR DESCRIPTION
When two SQS consumers process texture conversion events for the **same entity** concurrently (e.g., mac and windows finish at roughly the same time), a race condition can cause the registry to stay in `PENDING` status even though both platforms completed successfully.

This happens because `persistAndRotateStates` is not atomic: each consumer reads the entity's current bundle state, determines the overall status, and writes it back. If both consumers read before either writes, the second write overwrites the first — the last writer sees stale bundle data (only its own platform as COMPLETE) and computes status as `PENDING` instead of `COMPLETE`.

In practice, this means a fully converted scene can appear as still processing, and fallback registries may not be promoted/demoted correctly.

## How

The fix merges the bundle update, status determination, and state rotation into a **single database transaction**. This guarantees that when the status is computed, the bundle state reflects all prior updates — including those committed by a concurrent consumer moments earlier.

### New atomic path: `updateBundleAndRotateStates`

**DB layer** (`src/adapters/db.ts`):
- Added `persistRegistryInTransaction` — executes bundle update, optional version update, entity read, related registries read, status update, and state rotation all within one `pg.withTransaction` call.
- Five internal helpers (`_upsertRegistryBundle`, `_updateRegistryVersionWithBuildDate`, `_getRelatedRegistries`, `_insertRegistry`, `_updateRegistriesStatus`) accept a `QueryExecutor` parameter so they can run inside or outside a transaction.

**Registry component** (`src/logic/registry/component.ts`):
- Added `updateBundleAndRotateStates` — calls `persistRegistryInTransaction` with a `determineStatusAndRotate` callback that encapsulates the existing status determination and rotation logic (same code path as `persistAndRotateStates`, but running inside the transaction).

**Textures handler** (`src/logic/handlers/textures-handler.ts`):
- Non-OBSOLETE entities now use `registry.updateBundleAndRotateStates` instead of the previous sequence of `db.upsertRegistryBundle` → `db.updateRegistryVersionWithBuildDate` → `registry.persistAndRotateStates`.
- OBSOLETE entities still use the direct DB calls (they skip status rotation entirely, so atomicity isn't needed).

### Tests

**Unit tests** (`test/unit/logic/registry/component.spec.ts`):
- Added tests for `updateBundleAndRotateStates`: verifies the callback receives the post-update entity, correctly determines COMPLETE/PENDING/FAILED status, rotates older entities to OBSOLETE, and handles fallback promotion.
- Added tests proving concurrent events through the atomic path produce the correct final status.

**Unit tests** (`test/unit/logic/handlers/textures-handler.spec.ts`):
- Updated all non-OBSOLETE test cases to expect `registry.updateBundleAndRotateStates` instead of the old separate DB calls.

**Integration tests** (`test/integration/texture-conversion.spec.ts`):
- Full deployment → texture conversion flow: both platforms complete → COMPLETE status.
- One platform fails → FAILED status.
- Newer scene fails with older COMPLETE scene → older preserved as FALLBACK.
- Concurrent `Promise.all` texture events for the same entity → final status is COMPLETE (exercises the atomic transaction with real PostgreSQL).
- Concurrent texture events with an existing fallback scene → newer becomes COMPLETE, older correctly rotated to OBSOLETE.
