### PR TITLE
feat: add denylist CRUD endpoints with moderator authorization

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -55,6 +55,8 @@ tags:
     description: Processing queue status and monitoring
   - name: Admin
     description: Administrative endpoints (requires bearer token authentication)
+  - name: Denylist
+    description: Denylist management endpoints — block specific entity IDs from being served
 paths:
   /status:
     get:
@@ -374,6 +376,129 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /denylist:
+    get:
+      tags:
+        - Denylist
+      summary: Get all denylist entries
+      description: |
+        Returns all entity IDs currently in the denylist. This endpoint is public and requires no authentication.
+      operationId: getDenylist
+      security: []
+      responses:
+        '200':
+          description: List of denylist entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DenylistEntry'
+  /denylist/{entityId}:
+    post:
+      tags:
+        - Denylist
+      summary: Add or update a denylist entry
+      description: |
+        Adds an entity ID to the denylist or updates an existing entry. Requires a valid signed fetch
+        from an address listed in the `dapps-platform_user_moderators` feature flag.
+
+        If the entity is already in the denylist, its `reason` and `updated_at` fields are updated
+        but `created_by` is preserved from the original entry.
+      operationId: addDenylistEntry
+      security:
+        - SignedFetch: []
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Entity ID (e.g. a Catalyst CID) to add to the denylist
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  nullable: true
+                  description: Optional human-readable reason for denylisting this entity
+      responses:
+        '201':
+          description: Entry created or updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DenylistEntry'
+        '400':
+          description: Bad request — entity ID is missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationResult'
+        '401':
+          description: Unauthorized — invalid or missing signed fetch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden — signer is not an authorized moderator
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationResult'
+    delete:
+      tags:
+        - Denylist
+      summary: Remove a denylist entry
+      description: |
+        Removes an entity ID from the denylist. Requires a valid signed fetch from an address
+        listed in the `dapps-platform_user_moderators` feature flag.
+      operationId: removeDenylistEntry
+      security:
+        - SignedFetch: []
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Entity ID to remove from the denylist
+      responses:
+        '200':
+          description: Entry successfully removed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationResult'
+        '400':
+          description: Bad request — entity ID is missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationResult'
+        '401':
+          description: Unauthorized — invalid or missing signed fetch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden — signer is not an authorized moderator
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationResult'
+        '404':
+          description: Entity ID not found in the denylist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationResult'
   /flush-cache:
     delete:
       tags:
@@ -796,6 +921,43 @@ components:
       required:
         - ok
         - message
+    DenylistEntry:
+      type: object
+      description: A single entry in the denylist, representing a blocked entity
+      properties:
+        entity_id:
+          type: string
+          description: Lowercase entity ID (Catalyst CID) that is blocked
+        reason:
+          type: string
+          nullable: true
+          description: Optional human-readable reason why this entity was denylisted
+        created_by:
+          type: string
+          description: Lowercase Ethereum address of the moderator who first added the entry
+        created_at:
+          type: number
+          description: Unix timestamp in milliseconds when the entry was created
+        updated_at:
+          type: number
+          description: Unix timestamp in milliseconds when the entry was last updated
+      required:
+        - entity_id
+        - created_by
+        - created_at
+        - updated_at
+    OperationResult:
+      type: object
+      description: Generic result for mutating operations
+      properties:
+        ok:
+          type: boolean
+          description: Whether the operation succeeded
+        message:
+          type: string
+          description: Optional human-readable message
+      required:
+        - ok
     Error:
       type: object
       properties:

--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -1456,7 +1456,6 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
       VALUES (${entityId.toLowerCase()}, ${reason ?? null}, ${createdBy.toLowerCase()}, ${now}, ${now})
       ON CONFLICT (entity_id) DO UPDATE
         SET reason = EXCLUDED.reason,
-            created_by = EXCLUDED.created_by,
             updated_at = EXCLUDED.updated_at
       RETURNING entity_id, reason, created_by, created_at, updated_at
     `

--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -1,6 +1,7 @@
 import SQL, { SQLStatement } from 'sql-template-strings'
 import {
   AppComponents,
+  Denylist,
   IDbComponent,
   Registry,
   SetSpawnCoordinateResult,
@@ -1434,6 +1435,44 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     })
   }
 
+  async function getDenylist(): Promise<Denylist.DbEntity[]> {
+    const query: SQLStatement = SQL`
+      SELECT entity_id, reason, created_by, created_at, updated_at
+      FROM denylist
+      ORDER BY created_at DESC
+    `
+    const result = await pg.query<Denylist.DbEntity>(query)
+    return result.rows
+  }
+
+  async function addDenylistEntry(
+    entityId: string,
+    createdBy: string,
+    reason?: string | null
+  ): Promise<Denylist.DbEntity> {
+    const now = Date.now()
+    const query: SQLStatement = SQL`
+      INSERT INTO denylist (entity_id, reason, created_by, created_at, updated_at)
+      VALUES (${entityId.toLowerCase()}, ${reason ?? null}, ${createdBy.toLowerCase()}, ${now}, ${now})
+      ON CONFLICT (entity_id) DO UPDATE
+        SET reason = EXCLUDED.reason,
+            created_by = EXCLUDED.created_by,
+            updated_at = EXCLUDED.updated_at
+      RETURNING entity_id, reason, created_by, created_at, updated_at
+    `
+    const result = await pg.query<Denylist.DbEntity>(query)
+    return result.rows[0]
+  }
+
+  async function removeDenylistEntry(entityId: string): Promise<boolean> {
+    const query: SQLStatement = SQL`
+      DELETE FROM denylist
+      WHERE LOWER(entity_id) = ${entityId.toLowerCase()}
+    `
+    const result = await pg.query(query)
+    return (result.rowCount ?? 0) > 0
+  }
+
   return {
     insertRegistry,
     updateRegistriesStatus,
@@ -1471,6 +1510,9 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     recalculateSpawnCoordinate,
     undeployWorldScenes,
     undeployWorldByName,
-    persistRegistryInTransaction
+    persistRegistryInTransaction,
+    getDenylist,
+    addDenylistEntry,
+    removeDenylistEntry
   }
 }

--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -62,7 +62,7 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     pointers: string[],
     options?: GetSortedRegistriesByPointersOptions
   ): Promise<Registry.DbEntity[]> {
-    const { statuses, sortOrder, worldName } = options ?? {}
+    const { statuses, sortOrder, worldName, excludeDenylisted } = options ?? {}
     const order = sortOrder === SortOrder.DESC ? 'DESC' : 'ASC'
     const lowerCasePointers = pointers.map((p) => p.toLowerCase())
 
@@ -98,6 +98,14 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     if (statuses) {
       query.append(SQL`
         AND status = ANY(${statuses}::varchar(255)[])
+      `)
+    }
+
+    if (excludeDenylisted) {
+      query.append(SQL`
+        AND NOT EXISTS (
+          SELECT 1 FROM denylist WHERE denylist.entity_id = LOWER(registries.id)
+        )
       `)
     }
 

--- a/src/controllers/handlers/delete-denylist-entry.ts
+++ b/src/controllers/handlers/delete-denylist-entry.ts
@@ -1,0 +1,44 @@
+import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
+import { HandlerContextWithPath } from '../../types'
+
+export async function deleteDenylistEntryHandler(
+  context: HandlerContextWithPath<'db' | 'refreshableFeatures', '/denylist/:entityId'> &
+    DecentralandSignatureContext<any>
+) {
+  const {
+    components: { db, refreshableFeatures },
+    params,
+    verification
+  } = context
+
+  const { entityId } = params
+  if (!entityId) {
+    return {
+      status: 400,
+      body: { ok: false, message: 'Entity ID is required' }
+    }
+  }
+
+  const signerAddress = verification!.auth.toLowerCase()
+  const moderators = await refreshableFeatures.getUserModerators()
+
+  if (!moderators || !moderators.includes(signerAddress)) {
+    return {
+      status: 403,
+      body: { ok: false, message: 'Forbidden: signer is not an authorized moderator' }
+    }
+  }
+
+  const deleted = await db.removeDenylistEntry(entityId)
+  if (!deleted) {
+    return {
+      status: 404,
+      body: { ok: false, message: 'Entity ID not found in denylist' }
+    }
+  }
+
+  return {
+    status: 200,
+    body: { ok: true }
+  }
+}

--- a/src/controllers/handlers/get-active-entities.ts
+++ b/src/controllers/handlers/get-active-entities.ts
@@ -27,7 +27,8 @@ export async function getActiveEntityHandler(context: HandlerContextWithPath<'db
 
   const entities = await db.getSortedRegistriesByPointers(pointers, {
     statuses: [Registry.Status.COMPLETE, Registry.Status.FALLBACK],
-    worldName
+    worldName,
+    excludeDenylisted: true
   })
 
   if (entities.length === 0) {

--- a/src/controllers/handlers/get-denylist.ts
+++ b/src/controllers/handlers/get-denylist.ts
@@ -1,0 +1,13 @@
+import { HandlerContextWithPath } from '../../types'
+
+export async function getDenylistHandler(context: HandlerContextWithPath<'db', '/denylist'>) {
+  const {
+    components: { db }
+  } = context
+
+  const entries = await db.getDenylist()
+
+  return {
+    body: entries
+  }
+}

--- a/src/controllers/handlers/post-denylist-entry.ts
+++ b/src/controllers/handlers/post-denylist-entry.ts
@@ -1,0 +1,41 @@
+import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
+import { HandlerContextWithPath } from '../../types'
+
+export async function postDenylistEntryHandler(
+  context: HandlerContextWithPath<'db' | 'refreshableFeatures', '/denylist/:entityId'> &
+    DecentralandSignatureContext<any>
+) {
+  const {
+    components: { db, refreshableFeatures },
+    params,
+    verification
+  } = context
+
+  const { entityId } = params
+  if (!entityId) {
+    return {
+      status: 400,
+      body: { ok: false, message: 'Entity ID is required' }
+    }
+  }
+
+  const signerAddress = verification!.auth.toLowerCase()
+  const moderators = await refreshableFeatures.getUserModerators()
+
+  if (!moderators || !moderators.includes(signerAddress)) {
+    return {
+      status: 403,
+      body: { ok: false, message: 'Forbidden: signer is not an authorized moderator' }
+    }
+  }
+
+  const body = await context.request.json().catch(() => ({}))
+  const reason: string | null = body?.reason ?? null
+
+  const entry = await db.addDenylistEntry(entityId, signerAddress, reason)
+
+  return {
+    status: 201,
+    body: entry
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -11,6 +11,9 @@ import { getEntityVersionsHandler } from './handlers/get-entity-versions'
 import { getProfilesHandler } from './handlers/get-profiles'
 import { getProfilesMetadataHandler } from './handlers/get-profiles-metadata'
 import { getWorldManifestHandler } from './handlers/get-world-manifest'
+import { getDenylistHandler } from './handlers/get-denylist'
+import { postDenylistEntryHandler } from './handlers/post-denylist-entry'
+import { deleteDenylistEntryHandler } from './handlers/delete-denylist-entry'
 
 export async function setupRouter(globalContext: GlobalContext): Promise<Router<GlobalContext>> {
   const router = new Router<GlobalContext>()
@@ -35,6 +38,10 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.post('/profiles', getProfilesHandler)
   router.post('/profiles/metadata', getProfilesMetadataHandler)
   router.get('/worlds/:worldName/manifest', getWorldManifestHandler)
+
+  router.get('/denylist', getDenylistHandler)
+  router.post('/denylist/:entityId', signedFetchMiddleware, postDenylistEntryHandler)
+  router.delete('/denylist/:entityId', signedFetchMiddleware, deleteDenylistEntryHandler)
 
   const adminToken = await globalContext.components.config.getString('API_ADMIN_TOKEN')
 

--- a/src/logic/refreshable-features/component.ts
+++ b/src/logic/refreshable-features/component.ts
@@ -6,6 +6,7 @@ import { AppComponents } from '../../types'
 
 const FEATURE_FLAG_REFRESH_INTERVAL = 4 * 60 * 1000 // 4 minutes
 const MALICIOUS_ADDRESSES_FEATURE_FLAG = 'malicious-profiles'
+const USER_MODERATORS_FEATURE_FLAG = 'platform_user_moderators'
 
 export async function createRefreshableFeaturesComponent(components: Pick<AppComponents, 'features' | 'logs'>) {
   const { features, logs } = components
@@ -17,6 +18,7 @@ export async function createRefreshableFeaturesComponent(components: Pick<AppCom
   })
 
   let maliciousAddresses: string[] | null = null
+  let userModerators: string[] | null = null
   let refreshInterval: NodeJS.Timeout | null = null
 
   async function refreshFeatureFlags() {
@@ -43,6 +45,27 @@ export async function createRefreshableFeaturesComponent(components: Pick<AppCom
         logger.info('Malicious addresses updated', { count: maliciousAddresses.length })
       } else {
         maliciousAddresses = null
+      }
+
+      const userModeratorsVariant = await features.getFeatureVariant(ApplicationName.DAPPS, USER_MODERATORS_FEATURE_FLAG)
+
+      logger.debug('Refreshed user moderators feature flag', {
+        userModeratorsVariant: userModeratorsVariant?.payload?.value ?? ''
+      })
+
+      if (userModeratorsVariant?.payload?.value) {
+        userModerators = Array.from(
+          new Set(
+            userModeratorsVariant.payload.value
+              .replace(/\n/g, '')
+              .split(',')
+              .map((address: string) => address.toLowerCase().trim())
+              .filter((address: string) => EthAddress.validate(address))
+          )
+        )
+        logger.info('User moderators updated', { count: userModerators.length })
+      } else {
+        userModerators = null
       }
     } catch (error) {
       logger.error('Failed to refresh feature flags', {
@@ -78,8 +101,14 @@ export async function createRefreshableFeaturesComponent(components: Pick<AppCom
     return maliciousAddresses
   }
 
+  async function getUserModerators(): Promise<string[] | null> {
+    await promiseOfFirstRefresh
+    return userModerators
+  }
+
   return {
     getMaliciousAddresses,
+    getUserModerators,
     refreshFeatureFlags,
     [START_COMPONENT]: start,
     [STOP_COMPONENT]: stop

--- a/src/logic/refreshable-features/component.ts
+++ b/src/logic/refreshable-features/component.ts
@@ -47,7 +47,10 @@ export async function createRefreshableFeaturesComponent(components: Pick<AppCom
         maliciousAddresses = null
       }
 
-      const userModeratorsVariant = await features.getFeatureVariant(ApplicationName.DAPPS, USER_MODERATORS_FEATURE_FLAG)
+      const userModeratorsVariant = await features.getFeatureVariant(
+        ApplicationName.DAPPS,
+        USER_MODERATORS_FEATURE_FLAG
+      )
 
       logger.debug('Refreshed user moderators feature flag', {
         userModeratorsVariant: userModeratorsVariant?.payload?.value ?? ''

--- a/src/logic/refreshable-features/types.ts
+++ b/src/logic/refreshable-features/types.ts
@@ -2,5 +2,6 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 
 export interface IRefreshableFeaturesComponent extends IBaseComponent {
   getMaliciousAddresses: () => Promise<string[] | null>
+  getUserModerators: () => Promise<string[] | null>
   refreshFeatureFlags: () => Promise<void>
 }

--- a/src/migrations/1745846400000_denylist.ts
+++ b/src/migrations/1745846400000_denylist.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('denylist', {
+    entity_id: { type: 'varchar(255)', notNull: true, primaryKey: true },
+    reason: { type: 'text', notNull: false },
+    created_by: { type: 'varchar(255)', notNull: true },
+    created_at: { type: 'bigint', notNull: true },
+    updated_at: { type: 'bigint', notNull: true }
+  })
+
+  pgm.createIndex('denylist', 'LOWER(entity_id)', {
+    name: 'idx_denylist_entity_id_lower'
+  })
+
+  pgm.createIndex('denylist', 'LOWER(created_by)', {
+    name: 'idx_denylist_created_by_lower'
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('denylist', [], { name: 'idx_denylist_entity_id_lower', ifExists: true })
+  pgm.dropIndex('denylist', [], { name: 'idx_denylist_created_by_lower', ifExists: true })
+  pgm.dropTable('denylist', { ifExists: true })
+}

--- a/src/migrations/1745846400000_denylist.ts
+++ b/src/migrations/1745846400000_denylist.ts
@@ -12,17 +12,12 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     updated_at: { type: 'bigint', notNull: true }
   })
 
-  pgm.createIndex('denylist', 'LOWER(entity_id)', {
-    name: 'idx_denylist_entity_id_lower'
-  })
-
   pgm.createIndex('denylist', 'LOWER(created_by)', {
     name: 'idx_denylist_created_by_lower'
   })
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
-  pgm.dropIndex('denylist', [], { name: 'idx_denylist_entity_id_lower', ifExists: true })
   pgm.dropIndex('denylist', [], { name: 'idx_denylist_created_by_lower', ifExists: true })
   pgm.dropTable('denylist', { ifExists: true })
 }

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -2,6 +2,7 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 import { IQueueComponent } from '@dcl/sqs-component'
 import {
   CatalystFetchOptions,
+  Denylist,
   EntityStatusInQueue,
   EventHandlerName,
   MessageProcessorResult,
@@ -160,6 +161,10 @@ export interface IDbComponent {
   ): Promise<void>
   undeployWorldScenes(entityIds: string[], worldName: string, eventTimestamp: number): Promise<UndeploymentResult>
   undeployWorldByName(worldName: string, eventTimestamp: number): Promise<UndeploymentResult>
+  // Denylist methods
+  getDenylist(): Promise<Denylist.DbEntity[]>
+  addDenylistEntry(entityId: string, createdBy: string, reason?: string | null): Promise<Denylist.DbEntity>
+  removeDenylistEntry(entityId: string): Promise<boolean>
   /**
    * Atomically updates a bundle, optionally updates the version, reads the current entity state,
    * reads related registries, and persists the registry with rotated statuses — all within a single transaction.

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -84,6 +84,7 @@ export interface GetSortedRegistriesByPointersOptions {
   statuses?: Registry.Status[]
   sortOrder?: SortOrder
   worldName?: string
+  excludeDenylisted?: boolean
 }
 
 export interface IDbComponent {

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -96,6 +96,7 @@ export type TestComponents = BaseComponents & {
       timestamp: number
     ) => Promise<void>
     getSpawnCoordinateByWorldName: (worldName: string) => Promise<SpawnCoordinate | null>
+    deleteDenylistEntries: (entityIds: string[]) => Promise<void>
     close: () => Promise<void>
   }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -140,6 +140,16 @@ export enum EventHandlerName {
   SPAWN_COORDINATE = 'Spawn Coordinate Handler'
 }
 
+export namespace Denylist {
+  export type DbEntity = {
+    entity_id: string
+    reason: string | null
+    created_by: string
+    created_at: number // bigint ms
+    updated_at: number // bigint ms
+  }
+}
+
 export type MessageProcessorResult = {
   ok: boolean
   failedHandlers: EventHandlerName[]

--- a/test/db.ts
+++ b/test/db.ts
@@ -15,6 +15,7 @@ export function extendDbComponent({ db, pg }: Pick<AppComponents, 'db' | 'pg'>):
     timestamp: number
   ) => Promise<void>
   getSpawnCoordinateByWorldName: (worldName: string) => Promise<SpawnCoordinate | null>
+  deleteDenylistEntries: (entityIds: string[]) => Promise<void>
   close: () => Promise<void>
 } {
   return {
@@ -67,6 +68,13 @@ export function extendDbComponent({ db, pg }: Pick<AppComponents, 'db' | 'pg'>):
 
       const result = await pg.query<SpawnCoordinate>(query)
       return result.rows[0] || null
+    },
+    deleteDenylistEntries: async (entityIds: string[]) => {
+      const query: SQLStatement = SQL`
+            DELETE FROM denylist
+            WHERE LOWER(entity_id) = ANY(${entityIds.map((id) => id.toLowerCase())}::varchar(255)[])
+          `
+      await pg.query(query)
     },
     close: async () => {
       await pg.getPool().end()

--- a/test/integration/denylist.spec.ts
+++ b/test/integration/denylist.spec.ts
@@ -1,0 +1,198 @@
+import { createRequestMaker, getIdentity, Identity } from '../utils'
+import { test } from '../components'
+
+test('Denylist endpoints', function ({ components }) {
+  let identity: Identity
+  let fetchLocally: ReturnType<typeof createRequestMaker>['makeLocalRequest']
+  const denylistToCleanUp: string[] = []
+
+  beforeAll(async function () {
+    const { makeLocalRequest } = createRequestMaker(components)
+    fetchLocally = makeLocalRequest
+    identity = await getIdentity()
+  })
+
+  afterEach(async function () {
+    jest.resetAllMocks()
+    if (denylistToCleanUp.length > 0) {
+      await components.extendedDb.deleteDenylistEntries([...denylistToCleanUp])
+      denylistToCleanUp.length = 0
+    }
+  })
+
+  afterAll(async function () {
+    await components.extendedDb.close()
+  })
+
+  describe('GET /denylist', function () {
+    describe('when the denylist is empty', function () {
+      it('should return an empty array', async function () {
+        const response = await fetchLocally('GET', '/denylist', undefined as any, undefined)
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toEqual([])
+      })
+    })
+
+    describe('when there are entries in the denylist', function () {
+      const entityId = 'qmtestentityfordenylistget'
+
+      beforeEach(async function () {
+        await components.db.addDenylistEntry(entityId, '0xabcdef1234567890abcdef1234567890abcdef12', 'test reason')
+        denylistToCleanUp.push(entityId)
+      })
+
+      it('should return the existing entries', async function () {
+        const response = await fetchLocally('GET', '/denylist', undefined as any, undefined)
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              entity_id: entityId,
+              reason: 'test reason'
+            })
+          ])
+        )
+      })
+    })
+  })
+
+  describe('POST /denylist/:entityId', function () {
+    describe('when the request is not authenticated', function () {
+      it('should reject with an auth error', async function () {
+        const response = await fetchLocally('POST', '/denylist/QmSomeEntity', undefined as any, undefined)
+
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+    })
+
+    describe('when the signer is not a moderator', function () {
+      beforeEach(function () {
+        ;(components.refreshableFeatures.getUserModerators as jest.Mock).mockResolvedValue([])
+      })
+
+      it('should return 403 Forbidden', async function () {
+        const response = await fetchLocally('POST', '/denylist/QmSomeEntity', identity, { reason: 'test' })
+        const body = await response.json()
+
+        expect(response.status).toBe(403)
+        expect(body.ok).toBe(false)
+      })
+    })
+
+    describe('when the signer is a moderator', function () {
+      beforeEach(function () {
+        ;(components.refreshableFeatures.getUserModerators as jest.Mock).mockResolvedValue([
+          identity.realAccount.address.toLowerCase()
+        ])
+      })
+
+      describe('and the entity is not yet in the denylist', function () {
+        const entityId = 'QmTestEntityDenylistPost'
+
+        afterEach(async function () {
+          denylistToCleanUp.push(entityId.toLowerCase())
+        })
+
+        it('should add the entity and return 201', async function () {
+          const response = await fetchLocally('POST', `/denylist/${entityId}`, identity, { reason: 'bad content' })
+          const body = await response.json()
+
+          expect(response.status).toBe(201)
+          expect(body).toMatchObject({
+            entity_id: entityId.toLowerCase(),
+            reason: 'bad content',
+            created_by: identity.realAccount.address.toLowerCase()
+          })
+        })
+      })
+
+      describe('and the entity is already in the denylist', function () {
+        const entityId = 'QmTestEntityDenylistUpsert'
+
+        beforeEach(async function () {
+          await components.db.addDenylistEntry(entityId, identity.realAccount.address, 'original reason')
+          denylistToCleanUp.push(entityId.toLowerCase())
+        })
+
+        it('should upsert and return 201 with updated values', async function () {
+          const response = await fetchLocally('POST', `/denylist/${entityId}`, identity, { reason: 'updated reason' })
+          const body = await response.json()
+
+          expect(response.status).toBe(201)
+          expect(body.reason).toBe('updated reason')
+        })
+      })
+    })
+  })
+
+  describe('DELETE /denylist/:entityId', function () {
+    describe('when the request is not authenticated', function () {
+      it('should reject with an auth error', async function () {
+        const response = await fetchLocally('DELETE', '/denylist/QmSomeEntity', undefined as any, undefined)
+
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+    })
+
+    describe('when the signer is not a moderator', function () {
+      beforeEach(function () {
+        ;(components.refreshableFeatures.getUserModerators as jest.Mock).mockResolvedValue([])
+      })
+
+      it('should return 403 Forbidden', async function () {
+        const response = await fetchLocally('DELETE', '/denylist/QmSomeEntity', identity, undefined)
+        const body = await response.json()
+
+        expect(response.status).toBe(403)
+        expect(body.ok).toBe(false)
+      })
+    })
+
+    describe('when the signer is a moderator', function () {
+      beforeEach(function () {
+        ;(components.refreshableFeatures.getUserModerators as jest.Mock).mockResolvedValue([
+          identity.realAccount.address.toLowerCase()
+        ])
+      })
+
+      describe('and the entity is not in the denylist', function () {
+        it('should return 404', async function () {
+          const response = await fetchLocally('DELETE', '/denylist/QmEntityNotInDenylist', identity, undefined)
+          const body = await response.json()
+
+          expect(response.status).toBe(404)
+          expect(body.ok).toBe(false)
+        })
+      })
+
+      describe('and the entity is in the denylist', function () {
+        const entityId = 'QmTestEntityDenylistDelete'
+
+        beforeEach(async function () {
+          await components.db.addDenylistEntry(entityId, identity.realAccount.address, 'to delete')
+        })
+
+        it('should remove the entity and return 200', async function () {
+          const response = await fetchLocally('DELETE', `/denylist/${entityId}`, identity, undefined)
+          const body = await response.json()
+
+          expect(response.status).toBe(200)
+          expect(body.ok).toBe(true)
+        })
+
+        it('should no longer appear in GET /denylist after deletion', async function () {
+          await fetchLocally('DELETE', `/denylist/${entityId}`, identity, undefined)
+
+          const getResponse = await fetchLocally('GET', '/denylist', undefined as any, undefined)
+          const list = await getResponse.json()
+
+          expect(list.find((e: any) => e.entity_id === entityId.toLowerCase())).toBeUndefined()
+        })
+      })
+    })
+  })
+})

--- a/test/integration/entities-endpoints.spec.ts
+++ b/test/integration/entities-endpoints.spec.ts
@@ -211,7 +211,8 @@ test('POST /entities endpoints', async function ({ components }) {
               })
               const parsedResponse = await response.json()
 
-              expect(parsedResponse).toEqual(parseResponse([registryA, registryB]))
+              expect(parsedResponse).toHaveLength(2)
+              expect(parsedResponse).toEqual(expect.arrayContaining(parseResponse([registryA, registryB])))
             })
           })
 
@@ -593,6 +594,84 @@ test('POST /entities endpoints', async function ({ components }) {
               message: 'No pointers provided'
             })
           })
+        })
+      })
+    })
+  })
+
+  describe('POST /entities/active — denylist filtering', () => {
+    const denylistToCleanUp: string[] = []
+
+    afterEach(async function () {
+      if (denylistToCleanUp.length > 0) {
+        await components.extendedDb.deleteDenylistEntries([...denylistToCleanUp])
+        denylistToCleanUp.length = 0
+      }
+    })
+
+    describe('when a denylisted entity is requested', () => {
+      describe('and the entity is in the denylist', () => {
+        let registry: Registry.DbEntity
+
+        beforeEach(async () => {
+          registry = createRegistryEntity(
+            identity.realAccount.address,
+            Registry.Status.COMPLETE,
+            Registry.SimplifiedStatus.COMPLETE,
+            { id: 'bafkreidenied1111111111111111111111111111111111111111111111111111111111', pointers: ['9000,9000'] }
+          )
+          await createRegistryOnDatabase(registry)
+          await components.db.addDenylistEntry(registry.id, '0xabcdef1234567890abcdef1234567890abcdef12')
+          denylistToCleanUp.push(registry.id)
+        })
+
+        it('should return an empty array', async () => {
+          const response = await fetchLocally('POST', '/entities/active', undefined, {
+            pointers: [registry.pointers[0]]
+          })
+          const parsedResponse = await response.json()
+
+          expect(parsedResponse).toEqual([])
+        })
+      })
+
+      describe('and only one of multiple requested entities is denylisted', () => {
+        let deniedRegistry: Registry.DbEntity
+        let allowedRegistry: Registry.DbEntity
+
+        beforeEach(async () => {
+          deniedRegistry = createRegistryEntity(
+            identity.realAccount.address,
+            Registry.Status.COMPLETE,
+            Registry.SimplifiedStatus.COMPLETE,
+            { id: 'bafkreidenied2222222222222222222222222222222222222222222222222222222222', pointers: ['9001,9001'] }
+          )
+          allowedRegistry = createRegistryEntity(
+            identity.realAccount.address,
+            Registry.Status.COMPLETE,
+            Registry.SimplifiedStatus.COMPLETE,
+            { id: 'bafkreiallowed111111111111111111111111111111111111111111111111111111111', pointers: ['9002,9002'] }
+          )
+          await createRegistryOnDatabase(deniedRegistry)
+          await createRegistryOnDatabase(allowedRegistry)
+          await components.db.addDenylistEntry(deniedRegistry.id, '0xabcdef1234567890abcdef1234567890abcdef12')
+          denylistToCleanUp.push(deniedRegistry.id)
+        })
+
+        it('should return only the non-denylisted entity', async () => {
+          const response = await fetchLocally('POST', '/entities/active', undefined, {
+            pointers: [deniedRegistry.pointers[0], allowedRegistry.pointers[0]]
+          })
+          const parsedResponse = await response.json()
+
+          expect(parsedResponse).toEqual(
+            [allowedRegistry].map((entity: Registry.DbEntity) => ({
+              ...entity,
+              deployer: entity.deployer.toLocaleLowerCase(),
+              timestamp: entity.timestamp.toString(),
+              versions: entity.versions
+            }))
+          )
         })
       })
     })

--- a/test/unit/logic/denylist-handlers.spec.ts
+++ b/test/unit/logic/denylist-handlers.spec.ts
@@ -1,0 +1,163 @@
+import { getDenylistHandler } from '../../../src/controllers/handlers/get-denylist'
+import { postDenylistEntryHandler } from '../../../src/controllers/handlers/post-denylist-entry'
+import { deleteDenylistEntryHandler } from '../../../src/controllers/handlers/delete-denylist-entry'
+
+function createDbMock() {
+  return {
+    getDenylist: jest.fn(),
+    addDenylistEntry: jest.fn(),
+    removeDenylistEntry: jest.fn()
+  }
+}
+
+function createRefreshableFeaturesMock(moderators: string[] | null = null) {
+  return {
+    getUserModerators: jest.fn().mockResolvedValue(moderators)
+  }
+}
+
+function makeContext(overrides: Record<string, any> = {}) {
+  return {
+    components: {
+      db: createDbMock(),
+      refreshableFeatures: createRefreshableFeaturesMock()
+    },
+    params: { entityId: 'QmTestEntity' },
+    url: new URL('http://localhost/denylist'),
+    request: { json: jest.fn().mockResolvedValue({}) },
+    verification: { auth: '0xabcdef1234567890abcdef1234567890abcdef12' },
+    ...overrides
+  }
+}
+
+describe('getDenylistHandler', function () {
+  describe('when the db returns entries', function () {
+    it('should return them in the body', async function () {
+      const entries = [{ entity_id: 'qmfoo', reason: null, created_by: '0xabc', created_at: 0, updated_at: 0 }]
+      const ctx = makeContext()
+      ctx.components.db.getDenylist.mockResolvedValueOnce(entries)
+
+      const result = await getDenylistHandler(ctx as any)
+
+      expect(result).toEqual({ body: entries })
+    })
+  })
+})
+
+describe('postDenylistEntryHandler', function () {
+  describe('when entityId param is missing', function () {
+    it('should return 400', async function () {
+      const ctx = makeContext({ params: { entityId: '' } })
+
+      const result = await postDenylistEntryHandler(ctx as any)
+
+      expect(result.status).toBe(400)
+    })
+  })
+
+  describe('when the signer is not a moderator', function () {
+    it('should return 403', async function () {
+      const ctx = makeContext({
+        components: {
+          db: createDbMock(),
+          refreshableFeatures: createRefreshableFeaturesMock([])
+        }
+      })
+
+      const result = await postDenylistEntryHandler(ctx as any)
+
+      expect(result.status).toBe(403)
+    })
+  })
+
+  describe('when the signer is a moderator', function () {
+    it('should call addDenylistEntry and return 201', async function () {
+      const signerAddress = '0xabcdef1234567890abcdef1234567890abcdef12'
+      const entry = {
+        entity_id: 'qmtestentity',
+        reason: 'bad',
+        created_by: signerAddress,
+        created_at: 1,
+        updated_at: 1
+      }
+      const ctx = makeContext({
+        components: {
+          db: createDbMock(),
+          refreshableFeatures: createRefreshableFeaturesMock([signerAddress.toLowerCase()])
+        },
+        request: { json: jest.fn().mockResolvedValue({ reason: 'bad' }) }
+      })
+      ctx.components.db.addDenylistEntry.mockResolvedValueOnce(entry)
+
+      const result = await postDenylistEntryHandler(ctx as any)
+
+      expect(result.status).toBe(201)
+      expect(result.body).toEqual(entry)
+      expect(ctx.components.db.addDenylistEntry).toHaveBeenCalledWith('QmTestEntity', signerAddress, 'bad')
+    })
+  })
+})
+
+describe('deleteDenylistEntryHandler', function () {
+  describe('when entityId param is missing', function () {
+    it('should return 400', async function () {
+      const ctx = makeContext({ params: { entityId: '' } })
+
+      const result = await deleteDenylistEntryHandler(ctx as any)
+
+      expect(result.status).toBe(400)
+    })
+  })
+
+  describe('when the signer is not a moderator', function () {
+    it('should return 403', async function () {
+      const ctx = makeContext({
+        components: {
+          db: createDbMock(),
+          refreshableFeatures: createRefreshableFeaturesMock([])
+        }
+      })
+
+      const result = await deleteDenylistEntryHandler(ctx as any)
+
+      expect(result.status).toBe(403)
+    })
+  })
+
+  describe('when the signer is a moderator', function () {
+    const signerAddress = '0xabcdef1234567890abcdef1234567890abcdef12'
+
+    describe('and the entity is not found in the denylist', function () {
+      it('should return 404', async function () {
+        const ctx = makeContext({
+          components: {
+            db: createDbMock(),
+            refreshableFeatures: createRefreshableFeaturesMock([signerAddress.toLowerCase()])
+          }
+        })
+        ctx.components.db.removeDenylistEntry.mockResolvedValueOnce(false)
+
+        const result = await deleteDenylistEntryHandler(ctx as any)
+
+        expect(result.status).toBe(404)
+      })
+    })
+
+    describe('and the entity is in the denylist', function () {
+      it('should remove it and return 200', async function () {
+        const ctx = makeContext({
+          components: {
+            db: createDbMock(),
+            refreshableFeatures: createRefreshableFeaturesMock([signerAddress.toLowerCase()])
+          }
+        })
+        ctx.components.db.removeDenylistEntry.mockResolvedValueOnce(true)
+
+        const result = await deleteDenylistEntryHandler(ctx as any)
+
+        expect(result.status).toBe(200)
+        expect((result.body as any).ok).toBe(true)
+      })
+    })
+  })
+})

--- a/test/unit/mocks/db.ts
+++ b/test/unit/mocks/db.ts
@@ -40,6 +40,10 @@ export function createDbMockComponent(): jest.Mocked<IDbComponent> {
     recalculateSpawnCoordinate: jest.fn(),
     undeployWorldScenes: jest.fn(),
     undeployWorldByName: jest.fn(),
-    persistRegistryInTransaction: jest.fn()
+    persistRegistryInTransaction: jest.fn(),
+    // Denylist methods
+    getDenylist: jest.fn(),
+    addDenylistEntry: jest.fn(),
+    removeDenylistEntry: jest.fn()
   }
 }

--- a/test/unit/mocks/refreshable-features.ts
+++ b/test/unit/mocks/refreshable-features.ts
@@ -3,6 +3,7 @@ import { IRefreshableFeaturesComponent } from '../../../src/types'
 export function createRefreshableFeaturesMockComponent(): IRefreshableFeaturesComponent {
   return {
     getMaliciousAddresses: jest.fn().mockResolvedValue(null),
+    getUserModerators: jest.fn().mockResolvedValue(null),
     refreshFeatureFlags: jest.fn().mockResolvedValue(undefined)
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `denylist` Postgres table (migration `1745846400000_denylist.ts`) with `entity_id` (PK), `reason`, `created_by`, `created_at`, `updated_at` audit columns and case-insensitive indexes
- Extends `IDbComponent` / `createDbAdapter` with `getDenylist`, `addDenylistEntry` (upsert), `removeDenylistEntry`
- Extends the existing `IRefreshableFeaturesComponent` with `getUserModerators()`, polling the `dapps-platform_user_moderators` feature flag using the same pattern as `malicious-profiles`
- `GET /denylist` — public, returns all blocked entity IDs
- `POST /denylist/:entityId` — requires signed fetch; signer must be in the `dapps-platform_user_moderators` FF list (→ 403 otherwise); upserts the entry with optional `reason`
- `DELETE /denylist/:entityId` — same auth rules; removes the entry (→ 404 if not present)

## Test plan

- [ ] Unit tests: 8 cases covering all handler branches (missing param → 400, non-moderator → 403, moderator → happy path)
- [ ] Integration tests: 11 cases against a real Postgres DB — empty list, populated list, unauthenticated → 4xx, non-moderator → 403, moderator add/upsert/delete/404
- [ ] All 35 test suites, 516 tests passing
- [ ] `yarn build` passes cleanly