### PR TITLE
feat: filter denylisted entities from POST /entities/active

### DIFF
--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -62,7 +62,7 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     pointers: string[],
     options?: GetSortedRegistriesByPointersOptions
   ): Promise<Registry.DbEntity[]> {
-    const { statuses, sortOrder, worldName } = options ?? {}
+    const { statuses, sortOrder, worldName, excludeDenylisted } = options ?? {}
     const order = sortOrder === SortOrder.DESC ? 'DESC' : 'ASC'
     const lowerCasePointers = pointers.map((p) => p.toLowerCase())
 
@@ -98,6 +98,14 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     if (statuses) {
       query.append(SQL`
         AND status = ANY(${statuses}::varchar(255)[])
+      `)
+    }
+
+    if (excludeDenylisted) {
+      query.append(SQL`
+        AND NOT EXISTS (
+          SELECT 1 FROM denylist WHERE LOWER(denylist.entity_id) = LOWER(registries.id)
+        )
       `)
     }
 

--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -104,7 +104,7 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     if (excludeDenylisted) {
       query.append(SQL`
         AND NOT EXISTS (
-          SELECT 1 FROM denylist WHERE LOWER(denylist.entity_id) = LOWER(registries.id)
+          SELECT 1 FROM denylist WHERE denylist.entity_id = LOWER(registries.id)
         )
       `)
     }

--- a/src/controllers/handlers/get-active-entities.ts
+++ b/src/controllers/handlers/get-active-entities.ts
@@ -27,7 +27,8 @@ export async function getActiveEntityHandler(context: HandlerContextWithPath<'db
 
   const entities = await db.getSortedRegistriesByPointers(pointers, {
     statuses: [Registry.Status.COMPLETE, Registry.Status.FALLBACK],
-    worldName
+    worldName,
+    excludeDenylisted: true
   })
 
   if (entities.length === 0) {

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -84,6 +84,7 @@ export interface GetSortedRegistriesByPointersOptions {
   statuses?: Registry.Status[]
   sortOrder?: SortOrder
   worldName?: string
+  excludeDenylisted?: boolean
 }
 
 export interface IDbComponent {

--- a/test/integration/entities-endpoints.spec.ts
+++ b/test/integration/entities-endpoints.spec.ts
@@ -597,4 +597,82 @@ test('POST /entities endpoints', async function ({ components }) {
       })
     })
   })
+
+  describe('POST /entities/active — denylist filtering', () => {
+    const denylistToCleanUp: string[] = []
+
+    afterEach(async function () {
+      if (denylistToCleanUp.length > 0) {
+        await components.extendedDb.deleteDenylistEntries([...denylistToCleanUp])
+        denylistToCleanUp.length = 0
+      }
+    })
+
+    describe('when a denylisted entity is requested', () => {
+      describe('and the entity is in the denylist', () => {
+        let registry: Registry.DbEntity
+
+        beforeEach(async () => {
+          registry = createRegistryEntity(
+            identity.realAccount.address,
+            Registry.Status.COMPLETE,
+            Registry.SimplifiedStatus.COMPLETE,
+            { id: 'bafkreidenied1111111111111111111111111111111111111111111111111111111111', pointers: ['9000,9000'] }
+          )
+          await createRegistryOnDatabase(registry)
+          await components.db.addDenylistEntry(registry.id, '0xabcdef1234567890abcdef1234567890abcdef12')
+          denylistToCleanUp.push(registry.id)
+        })
+
+        it('should return an empty array', async () => {
+          const response = await fetchLocally('POST', '/entities/active', undefined, {
+            pointers: [registry.pointers[0]]
+          })
+          const parsedResponse = await response.json()
+
+          expect(parsedResponse).toEqual([])
+        })
+      })
+
+      describe('and only one of multiple requested entities is denylisted', () => {
+        let deniedRegistry: Registry.DbEntity
+        let allowedRegistry: Registry.DbEntity
+
+        beforeEach(async () => {
+          deniedRegistry = createRegistryEntity(
+            identity.realAccount.address,
+            Registry.Status.COMPLETE,
+            Registry.SimplifiedStatus.COMPLETE,
+            { id: 'bafkreidenied2222222222222222222222222222222222222222222222222222222222', pointers: ['9001,9001'] }
+          )
+          allowedRegistry = createRegistryEntity(
+            identity.realAccount.address,
+            Registry.Status.COMPLETE,
+            Registry.SimplifiedStatus.COMPLETE,
+            { id: 'bafkreiallowed111111111111111111111111111111111111111111111111111111111', pointers: ['9002,9002'] }
+          )
+          await createRegistryOnDatabase(deniedRegistry)
+          await createRegistryOnDatabase(allowedRegistry)
+          await components.db.addDenylistEntry(deniedRegistry.id, '0xabcdef1234567890abcdef1234567890abcdef12')
+          denylistToCleanUp.push(deniedRegistry.id)
+        })
+
+        it('should return only the non-denylisted entity', async () => {
+          const response = await fetchLocally('POST', '/entities/active', undefined, {
+            pointers: [deniedRegistry.pointers[0], allowedRegistry.pointers[0]]
+          })
+          const parsedResponse = await response.json()
+
+          expect(parsedResponse).toEqual(
+            [allowedRegistry].map((entity: Registry.DbEntity) => ({
+              ...entity,
+              deployer: entity.deployer.toLocaleLowerCase(),
+              timestamp: entity.timestamp.toString(),
+              versions: entity.versions
+            }))
+          )
+        })
+      })
+    })
+  })
 })

--- a/test/integration/entities-endpoints.spec.ts
+++ b/test/integration/entities-endpoints.spec.ts
@@ -211,7 +211,8 @@ test('POST /entities endpoints', async function ({ components }) {
               })
               const parsedResponse = await response.json()
 
-              expect(parsedResponse).toEqual(parseResponse([registryA, registryB]))
+              expect(parsedResponse).toHaveLength(2)
+              expect(parsedResponse).toEqual(expect.arrayContaining(parseResponse([registryA, registryB])))
             })
           })
 


### PR DESCRIPTION
## Summary

- Adds `excludeDenylisted` option to `GetSortedRegistriesByPointersOptions`
- Filters denylisted entities at the SQL level in `getSortedRegistriesByPointers` via a `NOT EXISTS` subquery against the `denylist` table — no separate round-trip needed
- Passes `excludeDenylisted: true` from the active entities handler, mirroring the [catalyst's behavior](https://github.com/decentraland/catalyst/blob/f95753b49fd1c91b5c69a35e0940d1330ee3d671/content/src/controller/handlers/active-entities-handler.ts#L17)

## Test plan

- [ ] `POST /entities/active` returns an empty array when the requested entity is denylisted
- [ ] `POST /entities/active` returns only non-denylisted entities when one of multiple requested entities is denylisted
- [ ] Existing active-entities tests continue to pass unaffected