### PR TITLE
fix: restore manually re-queued purged entities

### DIFF
--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -493,16 +493,59 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
 
   async function getHistoricalRegistryById(id: string): Promise<Registry.DbEntity | null> {
     const query: SQLStatement = SQL`
-      SELECT 
+      SELECT
         id, type, timestamp, deployer, pointers, content, metadata, status, bundles, versions
-      FROM 
+      FROM
         historical_registries
-      WHERE 
+      WHERE
         LOWER(id) = ${id.toLocaleLowerCase()}
     `
 
     const result = await pg.query<Registry.DbEntity>(query)
     return result.rows[0] || null
+  }
+
+  /**
+   * Atomically moves a registry from `historical_registries` back to `registries`.
+   * Used when a previously purged entity is manually re-queued for conversion so that
+   * incoming texture events have a live row to write back to. Bundles and versions are
+   * preserved from history; the entity status is reset to PENDING and will be recomputed
+   * by the next bundle update.
+   *
+   * @param id - The entity ID to restore
+   * @returns The restored registry entity, or null if no historical row was found
+   */
+  async function restoreFromHistoricalRegistry(id: string): Promise<Registry.DbEntity | null> {
+    return pg.withTransaction(async (client) => {
+      const lowerId = id.toLocaleLowerCase()
+
+      const selectResult = await client.query<Registry.DbEntity>(SQL`
+        SELECT id, type, timestamp, deployer, pointers, content, metadata, status, bundles, versions
+        FROM historical_registries
+        WHERE LOWER(id) = ${lowerId}
+      `)
+
+      const historical = selectResult.rows[0]
+      if (!historical) {
+        // A concurrent restore for the same entity may have already moved the row.
+        // Fall back to returning whatever is now in `registries`.
+        const currentResult = await client.query<Registry.DbEntity>(SQL`
+          SELECT id, type, timestamp, deployer, pointers, content, metadata, status, bundles, versions
+          FROM registries
+          WHERE LOWER(id) = ${lowerId}
+        `)
+        return currentResult.rows[0] || null
+      }
+
+      const restored = await _insertRegistry({ ...historical, status: Registry.Status.PENDING }, client)
+
+      await client.query(SQL`
+        DELETE FROM historical_registries
+        WHERE LOWER(id) = ${lowerId}
+      `)
+
+      return restored
+    })
   }
 
   async function upsertProfileIfNewer(profile: Sync.ProfileDbEntity): Promise<boolean> {
@@ -1506,6 +1549,7 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     insertHistoricalRegistry,
     getSortedHistoricalRegistriesByOwner,
     getHistoricalRegistryById,
+    restoreFromHistoricalRegistry,
     upsertProfileIfNewer,
     bulkUpsertProfilesIfNewer,
     getProfileByPointer,

--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -512,6 +512,12 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
    * preserved from history; the entity status is reset to PENDING and will be recomputed
    * by the next bundle update.
    *
+   * Uses SELECT ... FOR UPDATE on the historical row to serialize concurrent restores
+   * for the same entity. Without it, two concurrent texture events (e.g. windows + mac
+   * arriving simultaneously) could both read the historical row, and the slower one's
+   * upsert into `registries` would stomp the faster one's bundle update with stale
+   * bundle data from history.
+   *
    * @param id - The entity ID to restore
    * @returns The restored registry entity, or null if no historical row was found
    */
@@ -519,16 +525,19 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
     return pg.withTransaction(async (client) => {
       const lowerId = id.toLocaleLowerCase()
 
-      const selectResult = await client.query<Registry.DbEntity>(SQL`
+      const historicalResult = await client.query<Registry.DbEntity>(SQL`
         SELECT id, type, timestamp, deployer, pointers, content, metadata, status, bundles, versions
         FROM historical_registries
         WHERE LOWER(id) = ${lowerId}
+        FOR UPDATE
       `)
 
-      const historical = selectResult.rows[0]
+      const historical = historicalResult.rows[0]
       if (!historical) {
-        // A concurrent restore for the same entity may have already moved the row.
-        // Fall back to returning whatever is now in `registries`.
+        // Either the entity was never in history, or a concurrent restore already moved
+        // it. In the latter case the row is now in `registries` (and any in-flight bundle
+        // update from the winning thread is already applied or will be serialized by the
+        // row lock), so we return the live row as-is.
         const currentResult = await client.query<Registry.DbEntity>(SQL`
           SELECT id, type, timestamp, deployer, pointers, content, metadata, status, bundles, versions
           FROM registries

--- a/src/logic/handlers/status-handler.ts
+++ b/src/logic/handlers/status-handler.ts
@@ -14,6 +14,7 @@ export const createStatusEventHandler = ({
   function getEventProperties(event: any) {
     let entityId: string = ''
     let isLods: boolean = false
+    let isManuallyQueued: boolean = false
     const platforms: ('webgl' | 'windows' | 'mac')[] = []
 
     if (event.type === Events.Type.ASSET_BUNDLE && event.subType === Events.SubType.AssetBundle.MANUALLY_QUEUED) {
@@ -22,6 +23,7 @@ export const createStatusEventHandler = ({
       entityId = metadata.entityId
       platforms.push(metadata.platform)
       isLods = metadata.isLods
+      isManuallyQueued = true
     } else {
       const deploymentEvent = event as DeploymentToSqs
 
@@ -34,14 +36,15 @@ export const createStatusEventHandler = ({
     return {
       entityId,
       platforms,
-      isLods
+      isLods,
+      isManuallyQueued
     }
   }
 
   return {
     handle: async (event: DeploymentToSqs | AssetBundleConversionManuallyQueuedEvent): Promise<EventHandlerResult> => {
       try {
-        const { entityId, platforms, isLods } = getEventProperties(event)
+        const { entityId, platforms, isLods, isManuallyQueued } = getEventProperties(event)
 
         if (isLods) {
           logger.info('Skipping processing status for LODs', { entityId, platforms: platforms.join(', ') })
@@ -52,6 +55,9 @@ export const createStatusEventHandler = ({
 
         for (const platform of platforms) {
           await queuesStatusManager.markAsQueued(platform, entityId)
+          if (isManuallyQueued) {
+            await queuesStatusManager.markAsManuallyQueued(platform, entityId)
+          }
         }
 
         return { ok: true, handlerName: HANDLER_NAME }

--- a/src/logic/handlers/textures-handler.ts
+++ b/src/logic/handlers/textures-handler.ts
@@ -55,6 +55,7 @@ export const createTexturesEventHandler = ({
               logger.error('Failed to restore entity from historical registry', {
                 entityId: eventMetadata.entityId
               })
+              await queuesStatusManager.clearManualQueue(eventMetadata.platform, eventMetadata.entityId)
               if (!eventMetadata.isLods) {
                 await queuesStatusManager.markAsFinished(eventMetadata.platform, eventMetadata.entityId)
               }

--- a/src/logic/handlers/textures-handler.ts
+++ b/src/logic/handlers/textures-handler.ts
@@ -29,63 +29,93 @@ export const createTexturesEventHandler = ({
         if (!entity) {
           const historicalEntity = await db.getHistoricalRegistryById(eventMetadata.entityId)
           if (historicalEntity) {
-            logger.info('Entity was previously purged, skipping stale texture event', {
-              entityId: eventMetadata.entityId
+            const isManualRequeue = await queuesStatusManager.isManuallyQueued(
+              eventMetadata.platform,
+              eventMetadata.entityId
+            )
+
+            if (!isManualRequeue) {
+              logger.info('Entity was previously purged, skipping stale texture event', {
+                entityId: eventMetadata.entityId
+              })
+              if (!eventMetadata.isLods) {
+                await queuesStatusManager.markAsFinished(eventMetadata.platform, eventMetadata.entityId)
+              }
+              return { ok: true, handlerName: HANDLER_NAME }
+            }
+
+            logger.info('Entity was previously purged but is manually re-queued, restoring it', {
+              entityId: eventMetadata.entityId,
+              platform: eventMetadata.platform
             })
-            if (!eventMetadata.isLods) {
-              await queuesStatusManager.markAsFinished(eventMetadata.platform, eventMetadata.entityId)
+
+            entity = await db.restoreFromHistoricalRegistry(eventMetadata.entityId)
+
+            if (!entity) {
+              logger.error('Failed to restore entity from historical registry', {
+                entityId: eventMetadata.entityId
+              })
+              if (!eventMetadata.isLods) {
+                await queuesStatusManager.markAsFinished(eventMetadata.platform, eventMetadata.entityId)
+              }
+              return {
+                ok: false,
+                errors: [`Failed to restore entity ${eventMetadata.entityId} from historical registry`],
+                handlerName: HANDLER_NAME
+              }
             }
-            return { ok: true, handlerName: HANDLER_NAME }
-          }
 
-          logger.info('Entity not found in the database, will create it', { entityId: eventMetadata.entityId })
-          let fetchedEntity: Entity | null
-
-          if (event.metadata.isWorld) {
-            fetchedEntity = await worlds.getWorld(event.metadata.entityId)
+            await queuesStatusManager.clearManualQueue(eventMetadata.platform, eventMetadata.entityId)
           } else {
-            fetchedEntity = await catalyst.getEntityById(event.metadata.entityId)
-          }
+            logger.info('Entity not found in the database, will create it', { entityId: eventMetadata.entityId })
+            let fetchedEntity: Entity | null
 
-          if (!fetchedEntity) {
-            logger.error('Entity not found', { event: JSON.stringify(event) })
-            if (!eventMetadata.isLods) {
-              await queuesStatusManager.markAsFinished(eventMetadata.platform, eventMetadata.entityId)
+            if (event.metadata.isWorld) {
+              fetchedEntity = await worlds.getWorld(event.metadata.entityId)
+            } else {
+              fetchedEntity = await catalyst.getEntityById(event.metadata.entityId)
             }
-            return {
-              ok: false,
-              errors: [`Entity with id ${eventMetadata.entityId} was not found`],
-              handlerName: HANDLER_NAME
-            }
-          }
 
-          const defaultBundles: Registry.Bundles = {
-            assets: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
-            },
-            lods: {
-              windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
+            if (!fetchedEntity) {
+              logger.error('Entity not found', { event: JSON.stringify(event) })
+              if (!eventMetadata.isLods) {
+                await queuesStatusManager.markAsFinished(eventMetadata.platform, eventMetadata.entityId)
+              }
+              return {
+                ok: false,
+                errors: [`Entity with id ${eventMetadata.entityId} was not found`],
+                handlerName: HANDLER_NAME
+              }
             }
-          }
 
-          const defaultVersions: Registry.Versions = {
-            assets: {
-              windows: { version: '', buildDate: '' },
-              mac: { version: '', buildDate: '' },
-              webgl: { version: '', buildDate: '' }
+            const defaultBundles: Registry.Bundles = {
+              assets: {
+                windows: Registry.SimplifiedStatus.PENDING,
+                mac: Registry.SimplifiedStatus.PENDING,
+                webgl: Registry.SimplifiedStatus.PENDING
+              },
+              lods: {
+                windows: Registry.SimplifiedStatus.PENDING,
+                mac: Registry.SimplifiedStatus.PENDING,
+                webgl: Registry.SimplifiedStatus.PENDING
+              }
             }
-          }
 
-          entity = await registry.persistAndRotateStates({
-            ...fetchedEntity,
-            deployer: '', // cannot infer from textures event
-            bundles: defaultBundles,
-            versions: defaultVersions
-          })
+            const defaultVersions: Registry.Versions = {
+              assets: {
+                windows: { version: '', buildDate: '' },
+                mac: { version: '', buildDate: '' },
+                webgl: { version: '', buildDate: '' }
+              }
+            }
+
+            entity = await registry.persistAndRotateStates({
+              ...fetchedEntity,
+              deployer: '', // cannot infer from textures event
+              bundles: defaultBundles,
+              versions: defaultVersions
+            })
+          }
         }
 
         if (!eventMetadata.isLods) {

--- a/src/logic/queues-status-manager.ts
+++ b/src/logic/queues-status-manager.ts
@@ -1,4 +1,4 @@
-import { AppComponents, EntityStatusInQueue, IQueuesStatusManagerComponent } from '../types'
+import { AppComponents, EntityStatusInQueue, IQueuesStatusManagerComponent, ManualQueueMarker } from '../types'
 
 export function createQueuesStatusManagerComponent({
   memoryStorage
@@ -59,11 +59,11 @@ export function createQueuesStatusManagerComponent({
   }
 
   async function markAsManuallyQueued(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void> {
-    await memoryStorage.set(generateManualQueueKey(platform, entityId), { entityId, platform })
+    await memoryStorage.set<ManualQueueMarker>(generateManualQueueKey(platform, entityId), { entityId, platform })
   }
 
   async function isManuallyQueued(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<boolean> {
-    const entries = await memoryStorage.get<EntityStatusInQueue>(generateManualQueueKey(platform, entityId))
+    const entries = await memoryStorage.get<ManualQueueMarker>(generateManualQueueKey(platform, entityId))
     return entries.length > 0
   }
 

--- a/src/logic/queues-status-manager.ts
+++ b/src/logic/queues-status-manager.ts
@@ -7,6 +7,10 @@ export function createQueuesStatusManagerComponent({
     return `jobs:${platform}:${entityId}`
   }
 
+  function generateManualQueueKey(platform: 'windows' | 'mac' | 'webgl', entityId: string): string {
+    return `manual-jobs:${platform}:${entityId}`
+  }
+
   async function getStatus(key: string): Promise<EntityStatusInQueue | undefined> {
     const status = await memoryStorage.get<EntityStatusInQueue>(key)
 
@@ -54,9 +58,25 @@ export function createQueuesStatusManagerComponent({
       }))
   }
 
+  async function markAsManuallyQueued(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void> {
+    await memoryStorage.set(generateManualQueueKey(platform, entityId), { entityId, platform })
+  }
+
+  async function isManuallyQueued(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<boolean> {
+    const entries = await memoryStorage.get<EntityStatusInQueue>(generateManualQueueKey(platform, entityId))
+    return entries.length > 0
+  }
+
+  async function clearManualQueue(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void> {
+    await memoryStorage.purge(generateManualQueueKey(platform, entityId))
+  }
+
   return {
     markAsQueued,
     markAsFinished,
+    markAsManuallyQueued,
+    isManuallyQueued,
+    clearManualQueue,
     getAllPendingEntities
   }
 }

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -121,6 +121,7 @@ export interface IDbComponent {
   insertHistoricalRegistry(registry: Registry.DbEntity): Promise<Registry.DbEntity>
   getSortedHistoricalRegistriesByOwner(owner: EthAddress): Promise<Registry.DbEntity[]>
   getHistoricalRegistryById(id: string): Promise<Registry.DbEntity | null>
+  restoreFromHistoricalRegistry(id: string): Promise<Registry.DbEntity | null>
   // profiles
   upsertProfileIfNewer(profile: Sync.ProfileDbEntity): Promise<boolean>
   bulkUpsertProfilesIfNewer(profiles: Sync.ProfileDbEntity[]): Promise<string[]>
@@ -240,6 +241,9 @@ export interface ICacheStorage extends IBaseComponent {
 export interface IQueuesStatusManagerComponent {
   markAsQueued(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void>
   markAsFinished(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void>
+  markAsManuallyQueued(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void>
+  isManuallyQueued(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<boolean>
+  clearManualQueue(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void>
   getAllPendingEntities(platform: 'windows' | 'mac' | 'webgl'): Promise<EntityStatusInQueue[]>
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -113,6 +113,11 @@ export type EntityStatusInQueue = {
   status: EntityQueueStatusValue
 }
 
+export type ManualQueueMarker = {
+  entityId: string
+  platform: 'windows' | 'mac' | 'webgl'
+}
+
 export type CatalystFetchOptions = {
   parallelFetch?: {
     catalystServers: string[]

--- a/test/components.ts
+++ b/test/components.ts
@@ -92,6 +92,7 @@ async function initComponents(): Promise<TestComponents> {
     localFetch: await createLocalFetchCompoment(config),
     messageConsumer,
     messageProcessor,
+    queuesStatusManager,
     extendedDb: extendDbComponent({ db, pg }),
     refreshableFeatures: createRefreshableFeaturesMockComponent()
   }

--- a/test/integration/texture-conversion.spec.ts
+++ b/test/integration/texture-conversion.spec.ts
@@ -1,4 +1,10 @@
-import { AssetBundleConversionFinishedEvent, Entity, EntityType, Events } from '@dcl/schemas'
+import {
+  AssetBundleConversionFinishedEvent,
+  AssetBundleConversionManuallyQueuedEvent,
+  Entity,
+  EntityType,
+  Events
+} from '@dcl/schemas'
 import { AuthLinkType } from '@dcl/crypto'
 import { DeploymentToSqs } from '@dcl/schemas/dist/misc/deployments-to-sqs'
 import { Registry } from '../../src/types'
@@ -15,6 +21,7 @@ import { test } from '../components'
 test('texture conversion handling', async ({ components, spyComponents }) => {
   let identity: Identity
   const registriesToCleanUp: string[] = []
+  const historicalRegistriesToCleanUp: string[] = []
 
   beforeAll(async () => {
     identity = await getIdentity()
@@ -24,6 +31,10 @@ test('texture conversion handling', async ({ components, spyComponents }) => {
     if (registriesToCleanUp.length > 0) {
       await components.db.deleteRegistries(registriesToCleanUp)
       registriesToCleanUp.length = 0
+    }
+    if (historicalRegistriesToCleanUp.length > 0) {
+      await components.extendedDb.deleteHistoricalRegistries(historicalRegistriesToCleanUp)
+      historicalRegistriesToCleanUp.length = 0
     }
   })
 
@@ -80,6 +91,59 @@ test('texture conversion handling', async ({ components, spyComponents }) => {
   const mockGenesisCityDeployment = (entity: Entity): void => {
     spyComponents.worlds.isWorldDeployment.mockReturnValue(false)
     spyComponents.catalyst.getEntityById.mockResolvedValue(entity)
+  }
+
+  const createManualRequeueEvent = (
+    entityId: string,
+    platform: 'windows' | 'mac' | 'webgl'
+  ): AssetBundleConversionManuallyQueuedEvent => ({
+    type: Events.Type.ASSET_BUNDLE,
+    subType: Events.SubType.AssetBundle.MANUALLY_QUEUED,
+    key: entityId,
+    timestamp: Date.now(),
+    metadata: {
+      entityId,
+      platform,
+      isLods: false,
+      isPriority: false,
+      version: 'v1'
+    }
+  })
+
+  const seedHistoricalEntity = async (
+    entity: Entity,
+    overrides: Partial<Registry.DbEntity> = {}
+  ): Promise<Registry.DbEntity> => {
+    const dbEntity: Registry.DbEntity = {
+      ...entity,
+      deployer: identity.realAccount.address,
+      type: EntityType.SCENE,
+      status: Registry.Status.FAILED,
+      bundles: {
+        assets: {
+          windows: Registry.SimplifiedStatus.PENDING,
+          mac: Registry.SimplifiedStatus.PENDING,
+          webgl: Registry.SimplifiedStatus.PENDING
+        },
+        lods: {
+          windows: Registry.SimplifiedStatus.PENDING,
+          mac: Registry.SimplifiedStatus.PENDING,
+          webgl: Registry.SimplifiedStatus.PENDING
+        }
+      },
+      versions: {
+        assets: {
+          windows: { version: '', buildDate: '' },
+          mac: { version: '', buildDate: '' },
+          webgl: { version: '', buildDate: '' }
+        }
+      },
+      ...overrides
+    }
+
+    await components.extendedDb.insertHistoricalRegistry(dbEntity)
+    historicalRegistriesToCleanUp.push(dbEntity.id)
+    return dbEntity
   }
 
   describe('when both platform texture conversions complete for a scene', () => {
@@ -470,6 +534,241 @@ test('texture conversion handling', async ({ components, spyComponents }) => {
 
       expect(registryC).not.toBeNull()
       expect(registryC!.status).toBe(Registry.Status.FAILED)
+    })
+  })
+
+  describe('when a purged entity is manually re-queued and a texture event arrives', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = `texture-restore-happy-${Date.now()}`
+      const entity = createEntity({ id: entityId, pointers: ['910,910'], timestamp: 1000 })
+      await seedHistoricalEntity(entity, {
+        status: Registry.Status.FAILED,
+        bundles: {
+          assets: {
+            windows: Registry.SimplifiedStatus.FAILED,
+            mac: Registry.SimplifiedStatus.COMPLETE,
+            webgl: Registry.SimplifiedStatus.COMPLETE
+          },
+          lods: {
+            windows: Registry.SimplifiedStatus.PENDING,
+            mac: Registry.SimplifiedStatus.PENDING,
+            webgl: Registry.SimplifiedStatus.PENDING
+          }
+        }
+      })
+      registriesToCleanUp.push(entityId)
+
+      await components.messageProcessor.process(createManualRequeueEvent(entityId, 'windows'))
+      await components.messageProcessor.process(createTextureEvent(entityId, 'windows'))
+    })
+
+    it('should restore the entity into the active registries table', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+      expect(registry).not.toBeNull()
+    })
+
+    it('should apply the successful bundle update to the restored entity', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+      expect(registry!.bundles.assets.windows).toBe(Registry.SimplifiedStatus.COMPLETE)
+      expect(registry!.bundles.assets.mac).toBe(Registry.SimplifiedStatus.COMPLETE)
+    })
+
+    it('should mark the restored entity as complete', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+      expect(registry!.status).toBe(Registry.Status.COMPLETE)
+    })
+
+    it('should remove the historical row after the restore', async () => {
+      const historical = await components.db.getHistoricalRegistryById(entityId)
+      expect(historical).toBeNull()
+    })
+
+    it('should clear the manual re-queue marker so a follow-up stale event is skipped again', async () => {
+      const stillManuallyQueued = await components.queuesStatusManager.isManuallyQueued('windows', entityId)
+      expect(stillManuallyQueued).toBe(false)
+    })
+  })
+
+  describe('when a purged entity has no manual re-queue marker and a texture event arrives', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = `texture-restore-skip-${Date.now()}`
+      const entity = createEntity({ id: entityId, pointers: ['911,911'], timestamp: 1000 })
+      await seedHistoricalEntity(entity, { status: Registry.Status.FAILED })
+
+      await components.messageProcessor.process(createTextureEvent(entityId, 'windows'))
+    })
+
+    it('should not move the entity into the active registries table', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+      expect(registry).toBeNull()
+    })
+
+    it('should leave the historical row untouched', async () => {
+      const historical = await components.db.getHistoricalRegistryById(entityId)
+      expect(historical).not.toBeNull()
+      expect(historical!.status).toBe(Registry.Status.FAILED)
+    })
+  })
+
+  describe('when two concurrent texture events arrive for a purged, manually re-queued entity', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = `texture-restore-race-${Date.now()}`
+      const entity = createEntity({ id: entityId, pointers: ['912,912'], timestamp: 1000 })
+      await seedHistoricalEntity(entity, {
+        status: Registry.Status.FAILED,
+        bundles: {
+          assets: {
+            windows: Registry.SimplifiedStatus.FAILED,
+            mac: Registry.SimplifiedStatus.FAILED,
+            webgl: Registry.SimplifiedStatus.PENDING
+          },
+          lods: {
+            windows: Registry.SimplifiedStatus.PENDING,
+            mac: Registry.SimplifiedStatus.PENDING,
+            webgl: Registry.SimplifiedStatus.PENDING
+          }
+        }
+      })
+      registriesToCleanUp.push(entityId)
+
+      await components.messageProcessor.process(createManualRequeueEvent(entityId, 'windows'))
+      await components.messageProcessor.process(createManualRequeueEvent(entityId, 'mac'))
+
+      await Promise.all([
+        components.messageProcessor.process(createTextureEvent(entityId, 'windows')),
+        components.messageProcessor.process(createTextureEvent(entityId, 'mac'))
+      ])
+    })
+
+    it('should mark the restored entity as complete', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+      expect(registry).not.toBeNull()
+      expect(registry!.status).toBe(Registry.Status.COMPLETE)
+    })
+
+    it('should not let either platform stomp the other back to a stale historical bundle', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+      expect(registry!.bundles.assets.windows).toBe(Registry.SimplifiedStatus.COMPLETE)
+      expect(registry!.bundles.assets.mac).toBe(Registry.SimplifiedStatus.COMPLETE)
+    })
+
+    it('should remove the historical row exactly once', async () => {
+      const historical = await components.db.getHistoricalRegistryById(entityId)
+      expect(historical).toBeNull()
+    })
+  })
+
+  describe('when an OBSOLETE purged entity is manually re-queued while a newer COMPLETE entity exists at the same pointers', () => {
+    let olderEntityId: string
+    let newerEntityId: string
+
+    beforeEach(async () => {
+      olderEntityId = `texture-restore-obsolete-older-${Date.now()}`
+      newerEntityId = `texture-restore-obsolete-newer-${Date.now()}`
+
+      // Newer COMPLETE entity is the active one in registries at this pointer
+      const newerEntity = createEntity({ id: newerEntityId, pointers: ['913,913'], timestamp: 2000 })
+      mockGenesisCityDeployment(newerEntity)
+      registriesToCleanUp.push(newerEntityId)
+      await components.messageProcessor.process(createDeploymentMessage(newerEntityId))
+      await components.messageProcessor.process(createTextureEvent(newerEntityId, 'windows'))
+      await components.messageProcessor.process(createTextureEvent(newerEntityId, 'mac'))
+
+      // Older entity sits in historical_registries having been OBSOLETE-purged
+      const olderEntity = createEntity({ id: olderEntityId, pointers: ['913,913'], timestamp: 1000 })
+      await seedHistoricalEntity(olderEntity, {
+        status: Registry.Status.OBSOLETE,
+        bundles: {
+          assets: {
+            windows: Registry.SimplifiedStatus.FAILED,
+            mac: Registry.SimplifiedStatus.COMPLETE,
+            webgl: Registry.SimplifiedStatus.COMPLETE
+          },
+          lods: {
+            windows: Registry.SimplifiedStatus.PENDING,
+            mac: Registry.SimplifiedStatus.PENDING,
+            webgl: Registry.SimplifiedStatus.PENDING
+          }
+        }
+      })
+      registriesToCleanUp.push(olderEntityId)
+
+      await components.messageProcessor.process(createManualRequeueEvent(olderEntityId, 'windows'))
+      await components.messageProcessor.process(createTextureEvent(olderEntityId, 'windows'))
+    })
+
+    it('should still mark the restored older entity as OBSOLETE because a newer COMPLETE one exists', async () => {
+      const olderRegistry = await components.db.getRegistryById(olderEntityId)
+      expect(olderRegistry).not.toBeNull()
+      expect(olderRegistry!.status).toBe(Registry.Status.OBSOLETE)
+    })
+
+    it('should leave the newer COMPLETE entity untouched', async () => {
+      const newerRegistry = await components.db.getRegistryById(newerEntityId)
+      expect(newerRegistry).not.toBeNull()
+      expect(newerRegistry!.status).toBe(Registry.Status.COMPLETE)
+    })
+  })
+
+  describe('db.restoreFromHistoricalRegistry direct behavior', () => {
+    describe('when only a historical row exists', () => {
+      let entityId: string
+
+      beforeEach(async () => {
+        entityId = `db-restore-direct-historical-${Date.now()}`
+        const entity = createEntity({ id: entityId, pointers: ['914,914'], timestamp: 1000 })
+        await seedHistoricalEntity(entity, { status: Registry.Status.FAILED })
+        registriesToCleanUp.push(entityId)
+      })
+
+      it('should move the row into registries with status PENDING and remove the historical row', async () => {
+        const restored = await components.db.restoreFromHistoricalRegistry(entityId)
+
+        expect(restored).not.toBeNull()
+        expect(restored!.status).toBe(Registry.Status.PENDING)
+
+        const inRegistries = await components.db.getRegistryById(entityId)
+        const inHistorical = await components.db.getHistoricalRegistryById(entityId)
+        expect(inRegistries).not.toBeNull()
+        expect(inHistorical).toBeNull()
+      })
+    })
+
+    describe('when no historical row exists but a live registries row does', () => {
+      let entityId: string
+
+      beforeEach(async () => {
+        entityId = `db-restore-direct-fallback-${Date.now()}`
+        const entity = createEntity({ id: entityId, pointers: ['915,915'], timestamp: 1000 })
+        mockGenesisCityDeployment(entity)
+        registriesToCleanUp.push(entityId)
+        await components.messageProcessor.process(createDeploymentMessage(entityId))
+      })
+
+      it('should return the existing live row without modifying it', async () => {
+        const before = await components.db.getRegistryById(entityId)
+        const restored = await components.db.restoreFromHistoricalRegistry(entityId)
+        const after = await components.db.getRegistryById(entityId)
+
+        expect(restored).not.toBeNull()
+        expect(restored!.id).toBe(entityId)
+        expect(after!.status).toBe(before!.status)
+        expect(after!.bundles).toEqual(before!.bundles)
+      })
+    })
+
+    describe('when neither historical nor active registries have the row', () => {
+      it('should return null', async () => {
+        const entityId = `db-restore-direct-missing-${Date.now()}`
+        const restored = await components.db.restoreFromHistoricalRegistry(entityId)
+        expect(restored).toBeNull()
+      })
     })
   })
 })

--- a/test/integration/texture-conversion.spec.ts
+++ b/test/integration/texture-conversion.spec.ts
@@ -591,6 +591,65 @@ test('texture conversion handling', async ({ components, spyComponents }) => {
     })
   })
 
+  describe('when a purged entity is manually re-queued and the re-conversion itself fails', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = `texture-restore-fail-${Date.now()}`
+      const entity = createEntity({ id: entityId, pointers: ['916,916'], timestamp: 1000 })
+      await seedHistoricalEntity(entity, {
+        status: Registry.Status.FAILED,
+        bundles: {
+          assets: {
+            windows: Registry.SimplifiedStatus.FAILED,
+            mac: Registry.SimplifiedStatus.COMPLETE,
+            webgl: Registry.SimplifiedStatus.COMPLETE
+          },
+          lods: {
+            windows: Registry.SimplifiedStatus.PENDING,
+            mac: Registry.SimplifiedStatus.PENDING,
+            webgl: Registry.SimplifiedStatus.PENDING
+          }
+        }
+      })
+      registriesToCleanUp.push(entityId)
+
+      await components.messageProcessor.process(createManualRequeueEvent(entityId, 'windows'))
+      await components.messageProcessor.process(
+        createTextureEvent(entityId, 'windows', {
+          metadata: {
+            entityId,
+            platform: 'windows',
+            statusCode: ManifestStatusCode.ASSET_BUNDLE_BUILD_FAIL,
+            isLods: false,
+            isWorld: false,
+            version: 'v1'
+          }
+        })
+      )
+    })
+
+    it('should still restore the entity into the active registries table', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+      expect(registry).not.toBeNull()
+    })
+
+    it('should record the failed windows bundle on the restored entity', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+      expect(registry!.bundles.assets.windows).toBe(Registry.SimplifiedStatus.FAILED)
+    })
+
+    it('should mark the restored entity as failed because windows is still failed', async () => {
+      const registry = await components.db.getRegistryById(entityId)
+      expect(registry!.status).toBe(Registry.Status.FAILED)
+    })
+
+    it('should still clear the manual re-queue marker so the next stale event is skipped', async () => {
+      const stillManuallyQueued = await components.queuesStatusManager.isManuallyQueued('windows', entityId)
+      expect(stillManuallyQueued).toBe(false)
+    })
+  })
+
   describe('when a purged entity has no manual re-queue marker and a texture event arrives', () => {
     let entityId: string
 

--- a/test/unit/logic/handlers/status-handler.spec.ts
+++ b/test/unit/logic/handlers/status-handler.spec.ts
@@ -30,19 +30,24 @@ describe('status processor', () => {
 
   it('should handle deployment event and mark all platforms as pending', async () => {
     jest.spyOn(queuesStatusManager, 'markAsQueued')
+    jest.spyOn(queuesStatusManager, 'markAsManuallyQueued')
     const event = createDeploymentEvent('baf1')
     const result = await statusProcessor.handle(event)
     expect(result.ok).toBe(true)
     expect(queuesStatusManager.markAsQueued).toHaveBeenCalledTimes(3)
+    expect(queuesStatusManager.markAsManuallyQueued).not.toHaveBeenCalled()
   })
 
-  it('should handle asset bundle conversion manually queued event and mark the specific platform as pending', async () => {
+  it('should handle asset bundle conversion manually queued event and mark the specific platform as pending and manually queued', async () => {
     jest.spyOn(queuesStatusManager, 'markAsQueued')
+    jest.spyOn(queuesStatusManager, 'markAsManuallyQueued')
     const event = createAssetBundleConversionManuallyQueuedEvent('baf1', 'windows')
     const result = await statusProcessor.handle(event)
     expect(result.ok).toBe(true)
     expect(queuesStatusManager.markAsQueued).toHaveBeenCalledTimes(1)
     expect(queuesStatusManager.markAsQueued).toHaveBeenCalledWith('windows', 'baf1')
+    expect(queuesStatusManager.markAsManuallyQueued).toHaveBeenCalledTimes(1)
+    expect(queuesStatusManager.markAsManuallyQueued).toHaveBeenCalledWith('windows', 'baf1')
   })
 })
 

--- a/test/unit/logic/handlers/status-handler.spec.ts
+++ b/test/unit/logic/handlers/status-handler.spec.ts
@@ -49,6 +49,16 @@ describe('status processor', () => {
     expect(queuesStatusManager.markAsManuallyQueued).toHaveBeenCalledTimes(1)
     expect(queuesStatusManager.markAsManuallyQueued).toHaveBeenCalledWith('windows', 'baf1')
   })
+
+  it('should not set any marker when the manually queued event is for LODs', async () => {
+    jest.spyOn(queuesStatusManager, 'markAsQueued')
+    jest.spyOn(queuesStatusManager, 'markAsManuallyQueued')
+    const event = createAssetBundleConversionManuallyQueuedEvent('baf1', 'windows', true)
+    const result = await statusProcessor.handle(event)
+    expect(result.ok).toBe(true)
+    expect(queuesStatusManager.markAsQueued).not.toHaveBeenCalled()
+    expect(queuesStatusManager.markAsManuallyQueued).not.toHaveBeenCalled()
+  })
 })
 
 function createDeploymentEvent(entityId: string): DeploymentToSqs {
@@ -68,7 +78,8 @@ function createDeploymentEvent(entityId: string): DeploymentToSqs {
 
 function createAssetBundleConversionManuallyQueuedEvent(
   entityId: string,
-  platform: 'windows' | 'mac' | 'webgl'
+  platform: 'windows' | 'mac' | 'webgl',
+  isLods: boolean = false
 ): AssetBundleConversionManuallyQueuedEvent {
   return {
     type: Events.Type.ASSET_BUNDLE,
@@ -78,7 +89,7 @@ function createAssetBundleConversionManuallyQueuedEvent(
     metadata: {
       entityId,
       platform,
-      isLods: false,
+      isLods,
       isPriority: false,
       version: 'v1'
     }

--- a/test/unit/logic/handlers/textures-handler.spec.ts
+++ b/test/unit/logic/handlers/textures-handler.spec.ts
@@ -328,6 +328,150 @@ describe('textures-handler', () => {
           expect(pending.find((e: any) => e.entityId === 'purged-2')).toBeDefined()
         })
       })
+
+      describe('and the entity was previously purged but is manually re-queued', () => {
+        let event: AssetBundleConversionFinishedEvent
+        let result: { ok: boolean; errors?: string[] }
+        let historicalEntity: Registry.DbEntity
+        let restoredEntity: Registry.DbEntity
+
+        beforeEach(async () => {
+          event = createEvent()
+          const entity = createEntity()
+          const dbEntity = createDbEntity(entity)
+          historicalEntity = {
+            ...dbEntity,
+            status: Registry.Status.FAILED,
+            bundles: {
+              ...dbEntity.bundles,
+              assets: { ...dbEntity.bundles.assets, windows: Registry.SimplifiedStatus.FAILED }
+            }
+          }
+          restoredEntity = { ...historicalEntity, status: Registry.Status.PENDING }
+
+          db.getRegistryById = jest.fn().mockResolvedValue(null)
+          db.getHistoricalRegistryById = jest.fn().mockResolvedValue(historicalEntity)
+          db.restoreFromHistoricalRegistry = jest.fn().mockResolvedValue(restoredEntity)
+          registry.updateBundleAndRotateStates = jest
+            .fn()
+            .mockResolvedValue({ ...restoredEntity, status: Registry.Status.COMPLETE })
+
+          await memoryStorage.flush('manual-jobs:*')
+          await queuesStatusManager.markAsManuallyQueued(event.metadata.platform, event.metadata.entityId)
+
+          result = await handler.handle(event)
+        })
+
+        afterEach(async () => {
+          await memoryStorage.flush('manual-jobs:*')
+          jest.resetAllMocks()
+        })
+
+        it('should return ok', () => {
+          expect(result.ok).toBe(true)
+        })
+
+        it('should restore the entity from historical registries', () => {
+          expect(db.restoreFromHistoricalRegistry).toHaveBeenCalledWith(event.metadata.entityId)
+        })
+
+        it('should not refetch the entity from catalyst', () => {
+          expect(catalyst.getEntityById).not.toHaveBeenCalled()
+          expect(registry.persistAndRotateStates).not.toHaveBeenCalled()
+        })
+
+        it('should clear the manual re-queue marker after restoring', async () => {
+          expect(await queuesStatusManager.isManuallyQueued(event.metadata.platform, event.metadata.entityId)).toBe(
+            false
+          )
+        })
+
+        it('should process the texture event by updating the bundle and rotating states', () => {
+          expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
+            bundleUpdate: {
+              entityId: event.metadata.entityId,
+              platform: event.metadata.platform,
+              isLods: false,
+              status: Registry.SimplifiedStatus.COMPLETE
+            },
+            versionUpdate: {
+              entityId: event.metadata.entityId,
+              platform: event.metadata.platform,
+              version: event.metadata.version,
+              buildDate: new Date(event.timestamp).toISOString()
+            }
+          })
+        })
+      })
+
+      describe('and the entity was purged but only the deployment queue tracking was set (not a manual re-queue)', () => {
+        let event: AssetBundleConversionFinishedEvent
+        let result: { ok: boolean; errors?: string[] }
+
+        beforeEach(async () => {
+          event = createEvent()
+          const entity = createEntity()
+          const dbEntity = createDbEntity(entity)
+          const historicalEntity = { ...dbEntity, status: Registry.Status.FAILED }
+
+          db.getRegistryById = jest.fn().mockResolvedValue(null)
+          db.getHistoricalRegistryById = jest.fn().mockResolvedValue(historicalEntity)
+          db.restoreFromHistoricalRegistry = jest.fn()
+
+          await memoryStorage.flush('manual-jobs:*')
+          await queuesStatusManager.markAsQueued(event.metadata.platform, event.metadata.entityId)
+
+          result = await handler.handle(event)
+        })
+
+        afterEach(async () => {
+          await memoryStorage.flush('manual-jobs:*')
+          jest.resetAllMocks()
+        })
+
+        it('should return ok and skip processing (stale event)', () => {
+          expect(result.ok).toBe(true)
+          expect(db.restoreFromHistoricalRegistry).not.toHaveBeenCalled()
+          expect(registry.updateBundleAndRotateStates).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('and the entity was previously purged and the restore fails unexpectedly', () => {
+        let event: AssetBundleConversionFinishedEvent
+        let result: { ok: boolean; errors?: string[] }
+
+        beforeEach(async () => {
+          event = createEvent()
+          const entity = createEntity()
+          const dbEntity = createDbEntity(entity)
+          const historicalEntity = { ...dbEntity, status: Registry.Status.FAILED }
+
+          db.getRegistryById = jest.fn().mockResolvedValue(null)
+          db.getHistoricalRegistryById = jest.fn().mockResolvedValue(historicalEntity)
+          db.restoreFromHistoricalRegistry = jest.fn().mockResolvedValue(null)
+
+          await memoryStorage.flush('manual-jobs:*')
+          await queuesStatusManager.markAsManuallyQueued(event.metadata.platform, event.metadata.entityId)
+
+          result = await handler.handle(event)
+        })
+
+        afterEach(async () => {
+          await memoryStorage.flush('manual-jobs:*')
+          jest.resetAllMocks()
+        })
+
+        it('should return an error', () => {
+          expect(result.ok).toBe(false)
+          expect(result.errors).toEqual([
+            `Failed to restore entity ${event.metadata.entityId} from historical registry`
+          ])
+        })
+
+        it('should not process the texture event', () => {
+          expect(registry.updateBundleAndRotateStates).not.toHaveBeenCalled()
+        })
+      })
     })
 
     describe('when entity exists', () => {

--- a/test/unit/logic/handlers/textures-handler.spec.ts
+++ b/test/unit/logic/handlers/textures-handler.spec.ts
@@ -471,6 +471,12 @@ describe('textures-handler', () => {
         it('should not process the texture event', () => {
           expect(registry.updateBundleAndRotateStates).not.toHaveBeenCalled()
         })
+
+        it('should clear the manual re-queue marker so it does not stick around', async () => {
+          expect(await queuesStatusManager.isManuallyQueued(event.metadata.platform, event.metadata.entityId)).toBe(
+            false
+          )
+        })
       })
     })
 

--- a/test/unit/logic/message-processor.spec.ts
+++ b/test/unit/logic/message-processor.spec.ts
@@ -57,6 +57,9 @@ describe('message processor', () => {
     queuesStatusManager: {
       markAsQueued: jest.fn(),
       markAsFinished: jest.fn(),
+      markAsManuallyQueued: jest.fn(),
+      isManuallyQueued: jest.fn(),
+      clearManualQueue: jest.fn(),
       getAllPendingEntities: jest.fn()
     },
     db: createDbMockComponent(),

--- a/test/unit/logic/queues-status-manager.spec.ts
+++ b/test/unit/logic/queues-status-manager.spec.ts
@@ -141,4 +141,38 @@ describe('queues status manager', () => {
       expect(result).toContainEqual({ entityId, platform, status: EntityQueueStatusValue.BUNDLE_PENDING })
     })
   })
+
+  describe('manual re-queue tracking', () => {
+    afterEach(async () => {
+      await memoryStorage.purge(`manual-jobs:${platform}:${entityId}`)
+      await memoryStorage.purge(`manual-jobs:mac:${entityId}`)
+      await memoryStorage.purge(`manual-jobs:webgl:${entityId}`)
+    })
+
+    it('should return false from isManuallyQueued when no manual re-queue is tracked', async () => {
+      expect(await queuesStatusManager.isManuallyQueued(platform, entityId)).toBe(false)
+    })
+
+    it('should return true from isManuallyQueued after markAsManuallyQueued', async () => {
+      await queuesStatusManager.markAsManuallyQueued(platform, entityId)
+      expect(await queuesStatusManager.isManuallyQueued(platform, entityId)).toBe(true)
+    })
+
+    it('should not flip isManuallyQueued when only markAsQueued is called', async () => {
+      await queuesStatusManager.markAsQueued(platform, entityId)
+      expect(await queuesStatusManager.isManuallyQueued(platform, entityId)).toBe(false)
+    })
+
+    it('should return false from isManuallyQueued after clearManualQueue', async () => {
+      await queuesStatusManager.markAsManuallyQueued(platform, entityId)
+      await queuesStatusManager.clearManualQueue(platform, entityId)
+      expect(await queuesStatusManager.isManuallyQueued(platform, entityId)).toBe(false)
+    })
+
+    it('should be platform-scoped', async () => {
+      await queuesStatusManager.markAsManuallyQueued(platform, entityId)
+      expect(await queuesStatusManager.isManuallyQueued('mac', entityId)).toBe(false)
+      expect(await queuesStatusManager.isManuallyQueued(platform, entityId)).toBe(true)
+    })
+  })
 })

--- a/test/unit/mocks/db.ts
+++ b/test/unit/mocks/db.ts
@@ -16,6 +16,7 @@ export function createDbMockComponent(): jest.Mocked<IDbComponent> {
     insertHistoricalRegistry: jest.fn(),
     getSortedHistoricalRegistriesByOwner: jest.fn(),
     getHistoricalRegistryById: jest.fn(),
+    restoreFromHistoricalRegistry: jest.fn(),
     upsertProfileIfNewer: jest.fn(),
     bulkUpsertProfilesIfNewer: jest.fn().mockResolvedValue([]),
     getProfileByPointer: jest.fn(),


### PR DESCRIPTION
## Why

When an entity is in `FAILED` (or `OBSOLETE`) state, the periodic purger worker moves it out of `registries` and into `historical_registries`, then deletes the live row. That cleanup is correct in the normal case — those entities are dead.

But the system also exposes a manual re-conversion path via `AssetBundleConversionManuallyQueuedEvent`. Until now, that path silently dropped its result whenever the target entity had already been purged:

1. Conversion fails → entity ends up `FAILED`.
2. Purger sweeps it into `historical_registries` and deletes the `registries` row.
3. Someone re-queues conversion manually (a `MANUALLY_QUEUED` event lands in `status-handler`, which only updated `markAsQueued` — pure queue-tracking, no row insert).
4. Conversion finishes → `textures-handler` runs `db.getRegistryById` → null → finds the row only in `historical_registries` → unconditionally logs `Entity was previously purged, skipping stale texture event` and returns.

The successful (or freshly failed) re-conversion never updated the registry; the entity stayed visible only in the historical table with its old status. Re-deploying the entity was the only workaround.

The skip behavior is still desirable for genuinely stale leftovers (events that arrive long after a legitimate purge with no fresh request). What was missing was a way to tell the two apart.

## How

A new manual-only marker is stored next to the existing queue counters, keyed by `manual-jobs:<platform>:<entityId>`:

- **`status-handler`** now derives `isManuallyQueued` from the event type. When the event is `Events.SubType.AssetBundle.MANUALLY_QUEUED` it calls `queuesStatusManager.markAsManuallyQueued(platform, entityId)` in addition to the existing `markAsQueued`. Deployment events are unchanged — they never set this marker.
- **`textures-handler`**, when the entity is missing from `registries` but present in `historical_registries`, asks `queuesStatusManager.isManuallyQueued(...)`. If the marker is **not** present the existing stale-skip path runs. If it **is** present, it logs the restore, calls `db.restoreFromHistoricalRegistry(entityId)`, clears the marker with `clearManualQueue`, and continues processing the texture event normally. The downstream `markAsFinished` / bundle-update / status-rotation flow is reused as-is.
- **`db.restoreFromHistoricalRegistry`** runs in a `pg.withTransaction`: it `SELECT`s the historical row, `INSERT`s it back into `registries` (status reset to `PENDING`, bundles/versions preserved verbatim), and `DELETE`s the historical row. It is idempotent: if a concurrent platform event already moved the row, the loser falls back to returning whatever is now in `registries`, so two simultaneous platform events for the same entity don't fight each other.

`isQueued` from the earlier draft is removed — the manual marker is a strictly narrower signal than "anything queued", which avoids restoring on the merely-stale path where deployment-queue tracking happens to be set.

## Test plan

- [x] `yarn jest test/unit` — 349 / 349 passing (includes new coverage for `markAsManuallyQueued` / `isManuallyQueued` / `clearManualQueue`, the new "purged-but-manually-re-queued" path, the "purged-but-only-deployment-queue-tracked" skip path, and the restore-failure path)
- [ ] Manually re-queue a previously-purged entity in a non-prod environment and confirm the texture-handler logs `Entity was previously purged but is manually re-queued, restoring it` and that the entity appears in `registries` with the expected bundle status
- [ ] Re-queue concurrently for both platforms of the same entity and confirm both end up `complete` without errors (race-safety)
- [ ] Confirm that a late-arriving texture event for a previously-purged entity with no manual re-queue still produces the existing `Entity was previously purged, skipping stale texture event` log line