### PR TITLE
fix: only purge OBSOLETE registries, keep FAILED retryable

### DIFF
--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -404,12 +404,10 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
 
   async function getBatchOfDeprecatedRegistriesOlderThan(
     dateInMilliseconds: number,
-    failedIds: Set<string>,
+    excludedIds: Set<string>,
     limit: number = 100
   ): Promise<{ registries: Registry.DbEntity[] }> {
-    const parsedIds = Array.from(failedIds)
-      .map((id) => `'${id.toLocaleLowerCase()}'`)
-      .join(',')
+    const parsedIds = Array.from(excludedIds).map((id) => id.toLocaleLowerCase())
 
     const baseQuery = SQL`
       SELECT
@@ -419,7 +417,7 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
       WHERE
         timestamp < ${dateInMilliseconds}
         AND status = ${Registry.Status.OBSOLETE}::text
-        AND LOWER(id) NOT IN (${parsedIds})
+        AND LOWER(id) <> ALL(${parsedIds}::varchar(255)[])
       ORDER BY
         timestamp DESC
       LIMIT ${limit}

--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -412,15 +412,15 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
       .join(',')
 
     const baseQuery = SQL`
-      SELECT 
+      SELECT
         id, type, timestamp, deployer, pointers, content, metadata, status, bundles, versions
-      FROM 
+      FROM
         registries
-      WHERE 
+      WHERE
         timestamp < ${dateInMilliseconds}
-        AND status NOT IN (${Registry.Status.COMPLETE}::text, ${Registry.Status.FALLBACK}::text, ${Registry.Status.PENDING}::text)
+        AND status = ${Registry.Status.OBSOLETE}::text
         AND LOWER(id) NOT IN (${parsedIds})
-      ORDER BY 
+      ORDER BY
         timestamp DESC
       LIMIT ${limit}
     `

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -115,7 +115,7 @@ export interface IDbComponent {
   deleteRegistries(entityIds: string[]): Promise<void>
   getBatchOfDeprecatedRegistriesOlderThan(
     dateInMilliseconds: number,
-    failedIds: Set<string>,
+    excludedIds: Set<string>,
     limit: number
   ): Promise<{ registries: Registry.DbEntity[] }>
   insertHistoricalRegistry(registry: Registry.DbEntity): Promise<Registry.DbEntity>

--- a/test/integration/purger-eligibility.spec.ts
+++ b/test/integration/purger-eligibility.spec.ts
@@ -1,0 +1,81 @@
+import { Registry } from '../../src/types'
+import { createRegistryEntity, getIdentity, Identity } from '../utils'
+import { test } from '../components'
+
+test('getBatchOfDeprecatedRegistriesOlderThan eligibility', async ({ components }) => {
+  let identity: Identity
+  const registriesToCleanUp: string[] = []
+
+  beforeAll(async () => {
+    identity = await getIdentity()
+  })
+
+  afterEach(async () => {
+    if (registriesToCleanUp.length > 0) {
+      await components.db.deleteRegistries(registriesToCleanUp)
+      registriesToCleanUp.length = 0
+    }
+  })
+
+  afterAll(async () => {
+    await components.extendedDb.close()
+  })
+
+  const insertWithStatus = async (status: Registry.Status, timestamp: number): Promise<string> => {
+    const id = `purger-elig-${status}-${timestamp}-${Math.random().toString(36).slice(2, 8)}`
+    const entity = createRegistryEntity(identity.realAccount.address, status, Registry.SimplifiedStatus.COMPLETE, {
+      id,
+      timestamp
+    })
+    await components.extendedDb.insertRegistry(entity)
+    registriesToCleanUp.push(id)
+    return id
+  }
+
+  describe('when picking deprecated registries to purge', () => {
+    const olderThan = 10_000
+
+    let obsoleteId: string
+    let failedId: string
+    let completeId: string
+    let fallbackId: string
+    let pendingId: string
+
+    beforeEach(async () => {
+      obsoleteId = await insertWithStatus(Registry.Status.OBSOLETE, 1_000)
+      failedId = await insertWithStatus(Registry.Status.FAILED, 2_000)
+      completeId = await insertWithStatus(Registry.Status.COMPLETE, 3_000)
+      fallbackId = await insertWithStatus(Registry.Status.FALLBACK, 4_000)
+      pendingId = await insertWithStatus(Registry.Status.PENDING, 5_000)
+    })
+
+    it('returns only obsolete registries', async () => {
+      const { registries } = await components.db.getBatchOfDeprecatedRegistriesOlderThan(olderThan, new Set(), 100)
+
+      const ids = registries.map((r) => r.id)
+      expect(ids).toContain(obsoleteId)
+      expect(ids).not.toContain(failedId)
+      expect(ids).not.toContain(completeId)
+      expect(ids).not.toContain(fallbackId)
+      expect(ids).not.toContain(pendingId)
+    })
+
+    it('respects the timestamp filter', async () => {
+      const { registries } = await components.db.getBatchOfDeprecatedRegistriesOlderThan(500, new Set(), 100)
+
+      const ids = registries.map((r) => r.id)
+      expect(ids).not.toContain(obsoleteId)
+    })
+
+    it('respects the excluded ids set', async () => {
+      const { registries } = await components.db.getBatchOfDeprecatedRegistriesOlderThan(
+        olderThan,
+        new Set([obsoleteId.toLowerCase()]),
+        100
+      )
+
+      const ids = registries.map((r) => r.id)
+      expect(ids).not.toContain(obsoleteId)
+    })
+  })
+})


### PR DESCRIPTION
FAILED registries can be retried via manual AB-converter reconversion. Previously they were eligible for purging by getBatchOfDeprecatedRegistriesOlderThan, which moved them to historical_registries; the textures-handler then dropped any subsequent conversion-finished events for them as 'previously purged'.

Tightens the purge predicate to OBSOLETE only, so failed rows stay in registries and the next conversion event updates them through the normal path.