### PR TITLE
chore: remove webgl from the registry

### DIFF
--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -4,7 +4,7 @@
 
 **Key Capabilities:**
 
-- Tracks optimization status (pending/complete/failed) for Asset Bundles and LODs across platforms (Windows, Mac, WebGL)
+- Tracks optimization status (pending/complete/failed) for Asset Bundles and LODs across platforms (Windows, Mac)
 - Manages entity registry with deployer ownership, pointers, and optimization state transitions
 - Listens to SQS messages for deployment events and `AssetBundleConversionFinished` events
 - Provides REST API for querying entity optimization status by owner or entity ID

--- a/docs/database-schemas.md
+++ b/docs/database-schemas.md
@@ -90,7 +90,7 @@ Stores active entity registrations including scenes, wearables, emotes, and worl
 | `content` | JSONB | NOT NULL | Entity content files with file paths and content hashes. |
 | `metadata` | JSONB | NULL | Entity-specific metadata (varies by entity type). |
 | `status` | VARCHAR(255) | NOT NULL | Registry status: `complete`, `pending`, `failed`, `obsolete`, or `fallback`. |
-| `bundles` | JSONB | NOT NULL | Asset bundle and LOD conversion status per platform (Windows, Mac, WebGL). |
+| `bundles` | JSONB | NOT NULL | Asset bundle and LOD conversion status per platform (Windows, Mac). |
 | `deployer` | VARCHAR(255) | NOT NULL | Ethereum address of the entity deployer. |
 | `versions` | JSONB | NULL | Asset bundle version information per platform (version string, build date). |
 
@@ -109,13 +109,11 @@ Stores active entity registrations including scenes, wearables, emotes, and worl
 {
   "assets": {
     "windows": "complete|pending|failed",
-    "mac": "complete|pending|failed",
-    "webgl": "complete|pending|failed"
+    "mac": "complete|pending|failed"
   },
   "lods": {
     "windows": "complete|pending|failed",
-    "mac": "complete|pending|failed",
-    "webgl": "complete|pending|failed"
+    "mac": "complete|pending|failed"
   }
 }
 ```
@@ -126,8 +124,7 @@ Stores active entity registrations including scenes, wearables, emotes, and worl
 {
   "assets": {
     "windows": { "version": "v5", "buildDate": "2024-01-15" },
-    "mac": { "version": "v5", "buildDate": "2024-01-15" },
-    "webgl": { "version": "v5", "buildDate": "2024-01-15" }
+    "mac": { "version": "v5", "buildDate": "2024-01-15" }
   }
 }
 ```

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -687,15 +687,9 @@ components:
           items:
             type: string
           description: List of entity IDs with pending Mac asset bundle conversions
-        webglPendingJobs:
-          type: array
-          items:
-            type: string
-          description: List of entity IDs with pending WebGL asset bundle conversions
       required:
         - windowsPendingJobs
         - macPendingJobs
-        - webglPendingJobs
     VersionsRequest:
       type: object
       properties:
@@ -737,8 +731,6 @@ components:
               $ref: '#/components/schemas/VersionInfo'
             mac:
               $ref: '#/components/schemas/VersionInfo'
-            webgl:
-              $ref: '#/components/schemas/VersionInfo'
     VersionInfo:
       type: object
       description: Version details for a specific platform
@@ -770,13 +762,9 @@ components:
         mac:
           type: string
           enum: [pending, complete, failed]
-        webgl:
-          type: string
-          enum: [pending, complete, failed]
       required:
         - windows
         - mac
-        - webgl
     ProfilesRequest:
       type: object
       properties:

--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -1159,7 +1159,7 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
    * Sets the simplified status (PENDING, COMPLETE, FAILED) for either the assets or lods bundle type.
    *
    * @param id - The entity ID to update
-   * @param platform - The platform to update (e.g., 'windows', 'mac', 'webgl')
+   * @param platform - The platform to update (e.g., 'windows', 'mac')
    * @param lods - Whether to update the LODs bundle (true) or assets bundle (false)
    * @param status - The new simplified status for the bundle
    * @param executor - The transaction client to use for the query
@@ -1194,7 +1194,7 @@ export function createDbAdapter({ pg }: Pick<AppComponents, 'pg'>): IDbComponent
    * Internal: Updates the version and build date for a specific platform's asset bundle within a transaction.
    *
    * @param id - The entity ID to update
-   * @param platform - The platform to update (e.g., 'windows', 'mac', 'webgl')
+   * @param platform - The platform to update (e.g., 'windows', 'mac')
    * @param version - The asset bundle version string
    * @param buildDate - The ISO date string of when the bundle was built
    * @param executor - The transaction client to use for the query

--- a/src/controllers/handlers/get-entity-status.ts
+++ b/src/controllers/handlers/get-entity-status.ts
@@ -105,20 +105,18 @@ export async function getQueuesStatuses(context: HandlerContextWithPath<'queuesS
     components: { queuesStatusManager }
   } = context
 
-  async function getEntitiesIdsOfPendingJobs(platform: 'windows' | 'mac' | 'webgl') {
+  async function getEntitiesIdsOfPendingJobs(platform: 'windows' | 'mac') {
     return (await queuesStatusManager.getAllPendingEntities(platform)).map((pendingJob) => pendingJob.entityId)
   }
 
   const windowsPendingJobs = await getEntitiesIdsOfPendingJobs('windows')
   const macPendingJobs = await getEntitiesIdsOfPendingJobs('mac')
-  const webglPendingJobs = await getEntitiesIdsOfPendingJobs('webgl')
 
   return {
     status: 200,
     body: {
       windowsPendingJobs,
-      macPendingJobs,
-      webglPendingJobs
+      macPendingJobs
     },
     headers: {
       'Content-Type': 'application/json'

--- a/src/controllers/handlers/post-registry.ts
+++ b/src/controllers/handlers/post-registry.ts
@@ -41,11 +41,11 @@ export async function createRegistryHandler(
         continue
       }
 
-      const [macAssets, windowsAssets, webglAssets] = await Promise.all(
-        ['mac', 'windows', 'webgl'].map((platform) => entityStatusFetcher.fetchBundleManifestData(entityId, platform))
+      const [macAssets, windowsAssets] = await Promise.all(
+        ['mac', 'windows'].map((platform) => entityStatusFetcher.fetchBundleManifestData(entityId, platform))
       )
-      const [macLodsStatus, windowsLodsStatus, webglLodsStatus] = await Promise.all(
-        ['mac', 'windows', 'webgl'].map((platform) => entityStatusFetcher.fetchLODsStatus(entityId, platform))
+      const [macLodsStatus, windowsLodsStatus] = await Promise.all(
+        ['mac', 'windows'].map((platform) => entityStatusFetcher.fetchLODsStatus(entityId, platform))
       )
 
       const { status: macAssetsStatus, version: macAssetsVersion, buildDate: macAssetsBuildDate } = macAssets
@@ -54,26 +54,22 @@ export async function createRegistryHandler(
         version: windowsAssetsVersion,
         buildDate: windowsAssetsBuildDate
       } = windowsAssets
-      const { status: webglAssetsStatus, version: webglAssetsVersion, buildDate: webglAssetsBuildDate } = webglAssets
 
       const bundles: Registry.Bundles = {
         assets: {
           mac: macAssetsStatus,
-          windows: windowsAssetsStatus,
-          webgl: webglAssetsStatus
+          windows: windowsAssetsStatus
         },
         lods: {
           mac: macLodsStatus,
-          windows: windowsLodsStatus,
-          webgl: webglLodsStatus
+          windows: windowsLodsStatus
         }
       }
 
       const versions: Registry.Versions = {
         assets: {
           windows: { version: windowsAssetsVersion, buildDate: windowsAssetsBuildDate },
-          mac: { version: macAssetsVersion, buildDate: macAssetsBuildDate },
-          webgl: { version: webglAssetsVersion, buildDate: webglAssetsBuildDate }
+          mac: { version: macAssetsVersion, buildDate: macAssetsBuildDate }
         }
       }
 

--- a/src/logic/entity-status-fetcher.ts
+++ b/src/logic/entity-status-fetcher.ts
@@ -42,8 +42,7 @@ export async function createEntityStatusFetcherComponent({
   ): Promise<{ status: Registry.SimplifiedStatus; version: string; buildDate: string }> {
     return withRetry(
       async () => {
-        const manifestName = platform !== 'webgl' ? `${entityId}_${platform}` : entityId
-        const manifestUrl = `${ASSET_BUNDLE_CDN_URL}manifest/${manifestName}.json`
+        const manifestUrl = `${ASSET_BUNDLE_CDN_URL}manifest/${entityId}_${platform}.json`
 
         const response = await fetch.fetch(manifestUrl)
 
@@ -84,9 +83,8 @@ export async function createEntityStatusFetcherComponent({
     return withRetry(
       async () => {
         const lodsBaseUrl = `${ASSET_BUNDLE_CDN_URL}LOD`
-        const urlPlatformSuffix = platform === 'webgl' ? '' : `_${platform}`
         const allUrls = LEVEL_OF_DETAILS.map(
-          (levelOfDetail: string) => `${lodsBaseUrl}/${levelOfDetail}/${entityId}_${levelOfDetail}${urlPlatformSuffix}`
+          (levelOfDetail: string) => `${lodsBaseUrl}/${levelOfDetail}/${entityId}_${levelOfDetail}_${platform}`
         )
 
         const allResponses = await Promise.all(allUrls.map((url) => fetch.fetch(url, { method: 'HEAD' })))

--- a/src/logic/handlers/deployment-handler.ts
+++ b/src/logic/handlers/deployment-handler.ts
@@ -51,21 +51,18 @@ export const createDeploymentEventHandler = ({
         const defaultBundles: Registry.Bundles = {
           assets: {
             windows: Registry.SimplifiedStatus.PENDING,
-            mac: Registry.SimplifiedStatus.PENDING,
-            webgl: Registry.SimplifiedStatus.PENDING
+            mac: Registry.SimplifiedStatus.PENDING
           },
           lods: {
             windows: Registry.SimplifiedStatus.PENDING,
-            mac: Registry.SimplifiedStatus.PENDING,
-            webgl: Registry.SimplifiedStatus.PENDING
+            mac: Registry.SimplifiedStatus.PENDING
           }
         }
 
         const defaultVersions: Registry.Versions = {
           assets: {
             windows: { version: '', buildDate: '' },
-            mac: { version: '', buildDate: '' },
-            webgl: { version: '', buildDate: '' }
+            mac: { version: '', buildDate: '' }
           }
         }
 

--- a/src/logic/handlers/status-handler.ts
+++ b/src/logic/handlers/status-handler.ts
@@ -14,19 +14,20 @@ export const createStatusEventHandler = ({
   function getEventProperties(event: any) {
     let entityId: string = ''
     let isLods: boolean = false
-    const platforms: ('webgl' | 'windows' | 'mac')[] = []
+    const platforms: ('windows' | 'mac')[] = []
 
     if (event.type === Events.Type.ASSET_BUNDLE && event.subType === Events.SubType.AssetBundle.MANUALLY_QUEUED) {
       const { metadata } = event as AssetBundleConversionManuallyQueuedEvent
 
       entityId = metadata.entityId
-      platforms.push(metadata.platform)
+      if (metadata.platform !== 'webgl') {
+        platforms.push(metadata.platform as 'windows' | 'mac')
+      }
       isLods = metadata.isLods
     } else {
       const deploymentEvent = event as DeploymentToSqs
 
       entityId = deploymentEvent.entity.entityId
-      platforms.push('webgl')
       platforms.push('windows')
       platforms.push('mac')
     }

--- a/src/logic/handlers/textures-handler.ts
+++ b/src/logic/handlers/textures-handler.ts
@@ -21,6 +21,12 @@ export const createTexturesEventHandler = ({
     handle: async (event: AssetBundleConversionFinishedEvent): Promise<EventHandlerResult> => {
       try {
         const eventMetadata = event.metadata
+
+        if (eventMetadata.platform === 'webgl') {
+          logger.info('Skipping webgl asset bundle event', { entityId: eventMetadata.entityId })
+          return { ok: true, handlerName: HANDLER_NAME }
+        }
+
         let entity: Registry.DbEntity | null = await db.getRegistryById(eventMetadata.entityId)
 
         // Track if the entity was originally OBSOLETE to preserve its status later
@@ -62,21 +68,18 @@ export const createTexturesEventHandler = ({
           const defaultBundles: Registry.Bundles = {
             assets: {
               windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
+              mac: Registry.SimplifiedStatus.PENDING
             },
             lods: {
               windows: Registry.SimplifiedStatus.PENDING,
-              mac: Registry.SimplifiedStatus.PENDING,
-              webgl: Registry.SimplifiedStatus.PENDING
+              mac: Registry.SimplifiedStatus.PENDING
             }
           }
 
           const defaultVersions: Registry.Versions = {
             assets: {
               windows: { version: '', buildDate: '' },
-              mac: { version: '', buildDate: '' },
-              webgl: { version: '', buildDate: '' }
+              mac: { version: '', buildDate: '' }
             }
           }
 

--- a/src/logic/queues-status-manager.ts
+++ b/src/logic/queues-status-manager.ts
@@ -3,7 +3,7 @@ import { AppComponents, EntityStatusInQueue, IQueuesStatusManagerComponent } fro
 export function createQueuesStatusManagerComponent({
   memoryStorage
 }: Pick<AppComponents, 'memoryStorage'>): IQueuesStatusManagerComponent {
-  function generateCacheKey(platform: 'windows' | 'mac' | 'webgl', entityId: string): string {
+  function generateCacheKey(platform: 'windows' | 'mac', entityId: string): string {
     return `jobs:${platform}:${entityId}`
   }
 
@@ -15,7 +15,7 @@ export function createQueuesStatusManagerComponent({
     return status[0]
   }
 
-  async function markAsQueued(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void> {
+  async function markAsQueued(platform: 'windows' | 'mac', entityId: string): Promise<void> {
     const key = generateCacheKey(platform, entityId)
     const currentValue = (await getStatus(key)) || {
       entityId,
@@ -26,7 +26,7 @@ export function createQueuesStatusManagerComponent({
     await memoryStorage.set(key, { ...currentValue, status: currentValue.status + 1 })
   }
 
-  async function markAsFinished(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void> {
+  async function markAsFinished(platform: 'windows' | 'mac', entityId: string): Promise<void> {
     const key = generateCacheKey(platform, entityId)
     const currentValue = (await getStatus(key)) || {
       entityId,
@@ -44,7 +44,7 @@ export function createQueuesStatusManagerComponent({
     await memoryStorage.set<EntityStatusInQueue>(key, { ...currentValue, status: newStatus })
   }
 
-  async function getAllPendingEntities(platform: 'windows' | 'mac' | 'webgl'): Promise<EntityStatusInQueue[]> {
+  async function getAllPendingEntities(platform: 'windows' | 'mac'): Promise<EntityStatusInQueue[]> {
     const entities = (await memoryStorage.get<EntityStatusInQueue>(`jobs:${platform}:*`)) || []
     return entities
       .filter((entity: any) => entity.status > 0)

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -238,9 +238,9 @@ export interface ICacheStorage extends IBaseComponent {
 }
 
 export interface IQueuesStatusManagerComponent {
-  markAsQueued(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void>
-  markAsFinished(platform: 'windows' | 'mac' | 'webgl', entityId: string): Promise<void>
-  getAllPendingEntities(platform: 'windows' | 'mac' | 'webgl'): Promise<EntityStatusInQueue[]>
+  markAsQueued(platform: 'windows' | 'mac', entityId: string): Promise<void>
+  markAsFinished(platform: 'windows' | 'mac', entityId: string): Promise<void>
+  getAllPendingEntities(platform: 'windows' | 'mac'): Promise<EntityStatusInQueue[]>
 }
 
 export interface IProfilesCacheComponent {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -52,13 +52,13 @@ export namespace Registry {
     assets: {
       windows: SimplifiedStatus
       mac: SimplifiedStatus
-      webgl: SimplifiedStatus
+      webgl?: SimplifiedStatus
     }
     // LODs are optional - worlds don't support LODs
     lods?: {
       windows: SimplifiedStatus
       mac: SimplifiedStatus
-      webgl: SimplifiedStatus
+      webgl?: SimplifiedStatus
     }
   }
 
@@ -66,7 +66,7 @@ export namespace Registry {
     assets: {
       windows: { version: string; buildDate: string }
       mac: { version: string; buildDate: string }
-      webgl: { version: string; buildDate: string }
+      webgl?: { version: string; buildDate: string }
     }
   }
 
@@ -109,7 +109,7 @@ export enum EntityQueueStatusValue {
 
 export type EntityStatusInQueue = {
   entityId: string
-  platform: 'windows' | 'mac' | 'webgl'
+  platform: 'windows' | 'mac'
   status: EntityQueueStatusValue
 }
 

--- a/src/utils/key-generator.ts
+++ b/src/utils/key-generator.ts
@@ -1,3 +1,3 @@
-export function generateCacheKey(platform: 'windows' | 'mac' | 'webgl', entityId: string): string {
+export function generateCacheKey(platform: 'windows' | 'mac', entityId: string): string {
   return `jobs:${platform}:${entityId}`
 }

--- a/test/unit/logic/entity-status-fetcher.spec.ts
+++ b/test/unit/logic/entity-status-fetcher.spec.ts
@@ -30,33 +30,13 @@ describe('entity status fetcher', () => {
   const ENTITY_ID = 'bafkreig4pgot2bf6iw3bfxgo4nn7ich35ztjfjhjdomz2yqmtmnagpxhjq'
 
   describe('bundles status and version', () => {
-    it('should fetch COMPLETE bundle status and version for webgl platform', async () => {
+    it('should fetch COMPLETE bundle status and version using the platform-suffixed manifest URL', async () => {
       const sut: IEntityStatusFetcherComponent = await createEntityStatusFetcherComponent({
         fetch: mockFetch,
         logs,
         config
       })
-      const platform = 'webgl'
-
-      const manifest = createManifest(ManifestStatusCode.SUCCESS, 'v2')
-      mockFetch.fetch.mockResolvedValue({
-        ok: true,
-        json: jest.fn().mockResolvedValue(manifest)
-      })
-
-      const result = await sut.fetchBundleManifestData(ENTITY_ID, platform)
-      expect(result.status).toBe(Registry.SimplifiedStatus.COMPLETE)
-      expect(result.version).toBe('v2')
-      expect(mockFetch.fetch).toHaveBeenCalledWith(`${ASSET_BUNDLE_CDN_URL}manifest/${ENTITY_ID}.json`)
-    })
-
-    it('should fetch COMPLETE bundle status and version for non-webgl platform', async () => {
-      const sut: IEntityStatusFetcherComponent = await createEntityStatusFetcherComponent({
-        fetch: mockFetch,
-        logs,
-        config
-      })
-      const platform = 'android'
+      const platform = 'mac'
 
       const manifest = createManifest(ManifestStatusCode.SUCCESS, 'v3')
       mockFetch.fetch.mockResolvedValue({
@@ -83,7 +63,7 @@ describe('entity status fetcher', () => {
         json: jest.fn().mockResolvedValue(manifest)
       })
 
-      const result = await sut.fetchBundleManifestData(ENTITY_ID, 'webgl')
+      const result = await sut.fetchBundleManifestData(ENTITY_ID, 'mac')
       expect(result.status).toBe(Registry.SimplifiedStatus.COMPLETE)
       expect(result.version).toBe('v4')
     })
@@ -101,7 +81,7 @@ describe('entity status fetcher', () => {
         json: jest.fn().mockResolvedValue(manifest)
       })
 
-      const result = await sut.fetchBundleManifestData(ENTITY_ID, 'webgl')
+      const result = await sut.fetchBundleManifestData(ENTITY_ID, 'mac')
       expect(result.status).toBe(Registry.SimplifiedStatus.COMPLETE)
       expect(result.version).toBe('v5')
     })
@@ -119,7 +99,7 @@ describe('entity status fetcher', () => {
         json: jest.fn().mockResolvedValue(manifest)
       })
 
-      const result = await sut.fetchBundleManifestData(ENTITY_ID, 'webgl')
+      const result = await sut.fetchBundleManifestData(ENTITY_ID, 'mac')
       expect(result.status).toBe(Registry.SimplifiedStatus.FAILED)
       expect(result.version).toBe('v6')
     })
@@ -136,7 +116,7 @@ describe('entity status fetcher', () => {
         status: 404
       })
 
-      await expect(sut.fetchBundleManifestData(ENTITY_ID, 'webgl')).rejects.toThrow('Failed to fetch bundle status')
+      await expect(sut.fetchBundleManifestData(ENTITY_ID, 'mac')).rejects.toThrow('Failed to fetch bundle status')
     })
 
     it('should throw error for non-404 fetch failures', async () => {
@@ -151,7 +131,7 @@ describe('entity status fetcher', () => {
         status: 500
       })
 
-      await expect(sut.fetchBundleManifestData(ENTITY_ID, 'webgl')).rejects.toThrow('Failed to fetch bundle status')
+      await expect(sut.fetchBundleManifestData(ENTITY_ID, 'mac')).rejects.toThrow('Failed to fetch bundle status')
     })
   })
 
@@ -165,7 +145,7 @@ describe('entity status fetcher', () => {
 
       mockFetch.fetch.mockResolvedValue({ ok: true })
 
-      const status = await sut.fetchLODsStatus(ENTITY_ID, 'webgl')
+      const status = await sut.fetchLODsStatus(ENTITY_ID, 'mac')
       expect(status).toBe(Registry.SimplifiedStatus.COMPLETE)
       expect(mockFetch.fetch).toHaveBeenCalledTimes(3)
     })
@@ -182,7 +162,7 @@ describe('entity status fetcher', () => {
         .mockResolvedValueOnce({ ok: false })
         .mockResolvedValueOnce({ ok: true })
 
-      const status = await sut.fetchLODsStatus(ENTITY_ID, 'webgl')
+      const status = await sut.fetchLODsStatus(ENTITY_ID, 'mac')
       expect(status).toBe(Registry.SimplifiedStatus.FAILED)
     })
 
@@ -199,7 +179,7 @@ describe('entity status fetcher', () => {
         json: jest.fn().mockResolvedValue(manifest)
       })
 
-      const result = await sut.fetchBundleManifestData(ENTITY_ID, 'webgl')
+      const result = await sut.fetchBundleManifestData(ENTITY_ID, 'mac')
       expect(result.status).toBe(Registry.SimplifiedStatus.COMPLETE)
       expect(result.version).toBe('v7')
       expect(mockFetch.fetch).toHaveBeenCalledTimes(2)
@@ -214,17 +194,17 @@ describe('entity status fetcher', () => {
 
       mockFetch.fetch.mockRejectedValue(new Error('ECONNRESET'))
 
-      await expect(sut.fetchBundleManifestData(ENTITY_ID, 'webgl')).rejects.toThrow('ECONNRESET')
+      await expect(sut.fetchBundleManifestData(ENTITY_ID, 'mac')).rejects.toThrow('ECONNRESET')
       expect(mockFetch.fetch).toHaveBeenCalledTimes(2)
     })
 
-    it('should use platform suffix for non-webgl platforms', async () => {
+    it('should include the platform suffix in every LOD URL', async () => {
       const sut: IEntityStatusFetcherComponent = await createEntityStatusFetcherComponent({
         fetch: mockFetch,
         logs,
         config
       })
-      const platform = 'android'
+      const platform = 'mac'
 
       mockFetch.fetch.mockResolvedValue({ ok: true })
 

--- a/test/unit/logic/handlers/deployment-handler.spec.ts
+++ b/test/unit/logic/handlers/deployment-handler.spec.ts
@@ -120,20 +120,17 @@ describe('when handling deployment events', () => {
           bundles: {
             assets: {
               windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.COMPLETE,
-              webgl: Registry.SimplifiedStatus.COMPLETE
+              mac: Registry.SimplifiedStatus.COMPLETE
             },
             lods: {
               windows: Registry.SimplifiedStatus.COMPLETE,
-              mac: Registry.SimplifiedStatus.COMPLETE,
-              webgl: Registry.SimplifiedStatus.COMPLETE
+              mac: Registry.SimplifiedStatus.COMPLETE
             }
           },
           versions: {
             assets: {
               windows: { version: 'v1', buildDate: '' },
-              mac: { version: 'v1', buildDate: '' },
-              webgl: { version: 'v1', buildDate: '' }
+              mac: { version: 'v1', buildDate: '' }
             }
           }
         }
@@ -180,20 +177,17 @@ describe('when handling deployment events', () => {
             bundles: {
               assets: {
                 windows: Registry.SimplifiedStatus.PENDING,
-                mac: Registry.SimplifiedStatus.PENDING,
-                webgl: Registry.SimplifiedStatus.PENDING
+                mac: Registry.SimplifiedStatus.PENDING
               },
               lods: {
                 windows: Registry.SimplifiedStatus.PENDING,
-                mac: Registry.SimplifiedStatus.PENDING,
-                webgl: Registry.SimplifiedStatus.PENDING
+                mac: Registry.SimplifiedStatus.PENDING
               }
             },
             versions: {
               assets: {
                 windows: { version: '', buildDate: '' },
-                mac: { version: '', buildDate: '' },
-                webgl: { version: '', buildDate: '' }
+                mac: { version: '', buildDate: '' }
               }
             }
           })
@@ -262,13 +256,11 @@ describe('when handling deployment events', () => {
             bundles: {
               assets: {
                 windows: Registry.SimplifiedStatus.PENDING,
-                mac: Registry.SimplifiedStatus.PENDING,
-                webgl: Registry.SimplifiedStatus.PENDING
+                mac: Registry.SimplifiedStatus.PENDING
               },
               lods: {
                 windows: Registry.SimplifiedStatus.PENDING,
-                mac: Registry.SimplifiedStatus.PENDING,
-                webgl: Registry.SimplifiedStatus.PENDING
+                mac: Registry.SimplifiedStatus.PENDING
               }
             }
           })

--- a/test/unit/logic/handlers/status-handler.spec.ts
+++ b/test/unit/logic/handlers/status-handler.spec.ts
@@ -33,7 +33,9 @@ describe('status processor', () => {
     const event = createDeploymentEvent('baf1')
     const result = await statusProcessor.handle(event)
     expect(result.ok).toBe(true)
-    expect(queuesStatusManager.markAsQueued).toHaveBeenCalledTimes(3)
+    expect(queuesStatusManager.markAsQueued).toHaveBeenCalledTimes(2)
+    expect(queuesStatusManager.markAsQueued).toHaveBeenCalledWith('windows', 'baf1')
+    expect(queuesStatusManager.markAsQueued).toHaveBeenCalledWith('mac', 'baf1')
   })
 
   it('should handle asset bundle conversion manually queued event and mark the specific platform as pending', async () => {
@@ -63,7 +65,7 @@ function createDeploymentEvent(entityId: string): DeploymentToSqs {
 
 function createAssetBundleConversionManuallyQueuedEvent(
   entityId: string,
-  platform: 'windows' | 'mac' | 'webgl'
+  platform: 'windows' | 'mac'
 ): AssetBundleConversionManuallyQueuedEvent {
   return {
     type: Events.Type.ASSET_BUNDLE,

--- a/test/unit/logic/handlers/textures-handler.spec.ts
+++ b/test/unit/logic/handlers/textures-handler.spec.ts
@@ -62,20 +62,17 @@ describe('textures-handler', () => {
     bundles: {
       assets: {
         windows: Registry.SimplifiedStatus.PENDING,
-        mac: Registry.SimplifiedStatus.PENDING,
-        webgl: Registry.SimplifiedStatus.PENDING
+        mac: Registry.SimplifiedStatus.PENDING
       },
       lods: {
         windows: Registry.SimplifiedStatus.PENDING,
-        mac: Registry.SimplifiedStatus.PENDING,
-        webgl: Registry.SimplifiedStatus.PENDING
+        mac: Registry.SimplifiedStatus.PENDING
       }
     },
     versions: {
       assets: {
         windows: { version: '', buildDate: '' },
-        mac: { version: '', buildDate: '' },
-        webgl: { version: '', buildDate: '' }
+        mac: { version: '', buildDate: '' }
       }
     }
   })
@@ -208,6 +205,52 @@ describe('textures-handler', () => {
         const event = createEvent({
           metadata: {
             entityId: 'missing-1',
+            platform: 'windows',
+            statusCode: ManifestStatusCode.SUCCESS,
+            isLods: false,
+            isWorld: false,
+            version: 'v1'
+          }
+        })
+
+        await queuesStatusManager.markAsQueued('windows', 'missing-1')
+        db.getRegistryById = jest.fn().mockResolvedValue(null)
+        db.getHistoricalRegistryById = jest.fn().mockResolvedValue(null)
+        catalyst.getEntityById = jest.fn().mockResolvedValue(null)
+
+        await handler.handle(event)
+
+        const pending = await queuesStatusManager.getAllPendingEntities('windows')
+        expect(pending.find((e: any) => e.entityId === 'missing-1')).toBeUndefined()
+      })
+
+      it('should not clear the pending queue counter for lod events when entity not found', async () => {
+        const event = createEvent({
+          metadata: {
+            entityId: 'missing-2',
+            platform: 'windows',
+            statusCode: ManifestStatusCode.SUCCESS,
+            isLods: true,
+            isWorld: false,
+            version: 'v1'
+          }
+        })
+
+        await queuesStatusManager.markAsQueued('windows', 'missing-2')
+        db.getRegistryById = jest.fn().mockResolvedValue(null)
+        db.getHistoricalRegistryById = jest.fn().mockResolvedValue(null)
+        catalyst.getEntityById = jest.fn().mockResolvedValue(null)
+
+        await handler.handle(event)
+
+        const pending = await queuesStatusManager.getAllPendingEntities('windows')
+        expect(pending.find((e: any) => e.entityId === 'missing-2')).toBeDefined()
+      })
+
+      it('should skip processing webgl asset bundle events', async () => {
+        const event = createEvent({
+          metadata: {
+            entityId: '123',
             platform: 'webgl',
             statusCode: ManifestStatusCode.SUCCESS,
             isLods: false,
@@ -216,38 +259,11 @@ describe('textures-handler', () => {
           }
         })
 
-        await queuesStatusManager.markAsQueued('webgl', 'missing-1')
-        db.getRegistryById = jest.fn().mockResolvedValue(null)
-        db.getHistoricalRegistryById = jest.fn().mockResolvedValue(null)
-        catalyst.getEntityById = jest.fn().mockResolvedValue(null)
+        const result = await handler.handle(event)
 
-        await handler.handle(event)
-
-        const pending = await queuesStatusManager.getAllPendingEntities('webgl')
-        expect(pending.find((e: any) => e.entityId === 'missing-1')).toBeUndefined()
-      })
-
-      it('should not clear the pending queue counter for lod events when entity not found', async () => {
-        const event = createEvent({
-          metadata: {
-            entityId: 'missing-2',
-            platform: 'webgl',
-            statusCode: ManifestStatusCode.SUCCESS,
-            isLods: true,
-            isWorld: false,
-            version: 'v1'
-          }
-        })
-
-        await queuesStatusManager.markAsQueued('webgl', 'missing-2')
-        db.getRegistryById = jest.fn().mockResolvedValue(null)
-        db.getHistoricalRegistryById = jest.fn().mockResolvedValue(null)
-        catalyst.getEntityById = jest.fn().mockResolvedValue(null)
-
-        await handler.handle(event)
-
-        const pending = await queuesStatusManager.getAllPendingEntities('webgl')
-        expect(pending.find((e: any) => e.entityId === 'missing-2')).toBeDefined()
+        expect(result.ok).toBe(true)
+        expect(db.getRegistryById).not.toHaveBeenCalled()
+        expect(registry.updateBundleAndRotateStates).not.toHaveBeenCalled()
       })
 
       describe('and the entity was previously purged', () => {
@@ -401,41 +417,6 @@ describe('textures-handler', () => {
         })
       })
 
-      it('should update bundle status for webgl platform with already converted status', async () => {
-        const event = createEvent({
-          metadata: {
-            entityId: '123',
-            platform: 'webgl',
-            statusCode: ManifestStatusCode.ALREADY_CONVERTED,
-            isLods: false,
-            isWorld: false,
-            version: 'v1'
-          }
-        })
-        const entity = createEntity()
-        const dbEntity = createDbEntity(entity)
-        db.getRegistryById = jest.fn().mockResolvedValue(dbEntity)
-        registry.updateBundleAndRotateStates = jest.fn().mockResolvedValue(dbEntity)
-
-        const result = await handler.handle(event)
-
-        expect(result.ok).toBe(true)
-        expect(registry.updateBundleAndRotateStates).toHaveBeenCalledWith({
-          bundleUpdate: {
-            entityId: '123',
-            platform: 'webgl',
-            isLods: false,
-            status: Registry.SimplifiedStatus.COMPLETE
-          },
-          versionUpdate: {
-            entityId: '123',
-            platform: 'webgl',
-            version: 'v1',
-            buildDate: new Date(event.timestamp).toISOString()
-          }
-        })
-      })
-
       it('should mark bundle as failed when conversion fails and entity had PENDING status', async () => {
         const event = createEvent({
           metadata: {
@@ -494,20 +475,17 @@ describe('textures-handler', () => {
               bundles: {
                 assets: {
                   windows: Registry.SimplifiedStatus.COMPLETE,
-                  mac: Registry.SimplifiedStatus.COMPLETE,
-                  webgl: Registry.SimplifiedStatus.PENDING
+                  mac: Registry.SimplifiedStatus.COMPLETE
                 },
                 lods: {
                   windows: Registry.SimplifiedStatus.PENDING,
-                  mac: Registry.SimplifiedStatus.PENDING,
-                  webgl: Registry.SimplifiedStatus.PENDING
+                  mac: Registry.SimplifiedStatus.PENDING
                 }
               },
               versions: {
                 assets: {
                   windows: { version: 'v1', buildDate: '2024-01-01' },
-                  mac: { version: 'v1', buildDate: '2024-01-01' },
-                  webgl: { version: '', buildDate: '' }
+                  mac: { version: 'v1', buildDate: '2024-01-01' }
                 }
               }
             }
@@ -564,13 +542,11 @@ describe('textures-handler', () => {
               bundles: {
                 assets: {
                   windows: Registry.SimplifiedStatus.COMPLETE,
-                  mac: Registry.SimplifiedStatus.COMPLETE,
-                  webgl: Registry.SimplifiedStatus.PENDING
+                  mac: Registry.SimplifiedStatus.COMPLETE
                 },
                 lods: {
                   windows: Registry.SimplifiedStatus.COMPLETE,
-                  mac: Registry.SimplifiedStatus.COMPLETE,
-                  webgl: Registry.SimplifiedStatus.PENDING
+                  mac: Registry.SimplifiedStatus.COMPLETE
                 }
               }
             }
@@ -626,20 +602,17 @@ describe('textures-handler', () => {
               bundles: {
                 assets: {
                   windows: Registry.SimplifiedStatus.COMPLETE,
-                  mac: Registry.SimplifiedStatus.COMPLETE,
-                  webgl: Registry.SimplifiedStatus.PENDING
+                  mac: Registry.SimplifiedStatus.COMPLETE
                 },
                 lods: {
                   windows: Registry.SimplifiedStatus.PENDING,
-                  mac: Registry.SimplifiedStatus.PENDING,
-                  webgl: Registry.SimplifiedStatus.PENDING
+                  mac: Registry.SimplifiedStatus.PENDING
                 }
               },
               versions: {
                 assets: {
                   windows: { version: 'v1', buildDate: '2024-01-01' },
-                  mac: { version: 'v1', buildDate: '2024-01-01' },
-                  webgl: { version: '', buildDate: '' }
+                  mac: { version: 'v1', buildDate: '2024-01-01' }
                 }
               }
             }
@@ -648,8 +621,7 @@ describe('textures-handler', () => {
               versions: {
                 assets: {
                   windows: { version: 'v2', buildDate: '2024-01-02' },
-                  mac: { version: 'v1', buildDate: '2024-01-01' },
-                  webgl: { version: '', buildDate: '' }
+                  mac: { version: 'v1', buildDate: '2024-01-01' }
                 }
               }
             }
@@ -784,13 +756,11 @@ describe('textures-handler', () => {
             bundles: {
               assets: {
                 windows: Registry.SimplifiedStatus.COMPLETE,
-                mac: Registry.SimplifiedStatus.COMPLETE,
-                webgl: Registry.SimplifiedStatus.PENDING
+                mac: Registry.SimplifiedStatus.COMPLETE
               },
               lods: {
                 windows: Registry.SimplifiedStatus.PENDING,
-                mac: Registry.SimplifiedStatus.PENDING,
-                webgl: Registry.SimplifiedStatus.PENDING
+                mac: Registry.SimplifiedStatus.PENDING
               }
             }
           }
@@ -799,8 +769,7 @@ describe('textures-handler', () => {
             versions: {
               assets: {
                 windows: { version: 'v2', buildDate: '2024-01-02' },
-                mac: { version: 'v1', buildDate: '2024-01-01' },
-                webgl: { version: '', buildDate: '' }
+                mac: { version: 'v1', buildDate: '2024-01-01' }
               }
             }
           }

--- a/test/unit/logic/queues-status-manager.spec.ts
+++ b/test/unit/logic/queues-status-manager.spec.ts
@@ -12,7 +12,6 @@ describe('queues status manager', () => {
     jest.clearAllMocks()
     await memoryStorage.purge(`jobs:${platform}:${entityId}`)
     await memoryStorage.purge(`jobs:mac:${entityId}`)
-    await memoryStorage.purge(`jobs:webgl:${entityId}`)
   })
 
   it('should return empty for pending entities when there are no pending entities', async () => {
@@ -91,11 +90,9 @@ describe('queues status manager', () => {
     it('should return pending entities for multiple platforms', async () => {
       await queuesStatusManager.markAsQueued(platform, entityId)
       await queuesStatusManager.markAsQueued('mac', entityId)
-      await queuesStatusManager.markAsQueued('webgl', entityId)
 
       const windowsResult = await queuesStatusManager.getAllPendingEntities(platform)
       const macResult = await queuesStatusManager.getAllPendingEntities('mac')
-      const webglResult = await queuesStatusManager.getAllPendingEntities('webgl')
 
       expect(windowsResult).toContainEqual({
         entityId,
@@ -103,7 +100,6 @@ describe('queues status manager', () => {
         status: EntityQueueStatusValue.BUNDLE_PENDING
       })
       expect(macResult).toContainEqual({ entityId, platform: 'mac', status: EntityQueueStatusValue.BUNDLE_PENDING })
-      expect(webglResult).toContainEqual({ entityId, platform: 'webgl', status: EntityQueueStatusValue.BUNDLE_PENDING })
     })
 
     it('should not return stale entities', async () => {

--- a/test/unit/logic/registry/component.spec.ts
+++ b/test/unit/logic/registry/component.spec.ts
@@ -38,20 +38,17 @@ describe('when using the registry component', () => {
       bundles: {
         assets: {
           mac: Registry.SimplifiedStatus.PENDING,
-          windows: Registry.SimplifiedStatus.PENDING,
-          webgl: Registry.SimplifiedStatus.PENDING
+          windows: Registry.SimplifiedStatus.PENDING
         },
         lods: {
           mac: Registry.SimplifiedStatus.PENDING,
-          windows: Registry.SimplifiedStatus.PENDING,
-          webgl: Registry.SimplifiedStatus.PENDING
+          windows: Registry.SimplifiedStatus.PENDING
         }
       },
       versions: {
         assets: {
           windows: { version: '', buildDate: '' },
-          mac: { version: '', buildDate: '' },
-          webgl: { version: '', buildDate: '' }
+          mac: { version: '', buildDate: '' }
         }
       },
       ...partial

--- a/test/unit/mocks/registry.ts
+++ b/test/unit/mocks/registry.ts
@@ -15,20 +15,17 @@ export function createRegistryMockComponent(): jest.Mocked<IRegistryComponent> {
       bundles: {
         assets: {
           windows: Registry.SimplifiedStatus.PENDING,
-          mac: Registry.SimplifiedStatus.PENDING,
-          webgl: Registry.SimplifiedStatus.PENDING
+          mac: Registry.SimplifiedStatus.PENDING
         },
         lods: {
           windows: Registry.SimplifiedStatus.PENDING,
-          mac: Registry.SimplifiedStatus.PENDING,
-          webgl: Registry.SimplifiedStatus.PENDING
+          mac: Registry.SimplifiedStatus.PENDING
         }
       },
       versions: {
         assets: {
           windows: { version: '', buildDate: '' },
-          mac: { version: '', buildDate: '' },
-          webgl: { version: '', buildDate: '' }
+          mac: { version: '', buildDate: '' }
         }
       }
     } as Registry.DbEntity),
@@ -44,20 +41,17 @@ export function createRegistryMockComponent(): jest.Mocked<IRegistryComponent> {
       bundles: {
         assets: {
           windows: Registry.SimplifiedStatus.PENDING,
-          mac: Registry.SimplifiedStatus.PENDING,
-          webgl: Registry.SimplifiedStatus.PENDING
+          mac: Registry.SimplifiedStatus.PENDING
         },
         lods: {
           windows: Registry.SimplifiedStatus.PENDING,
-          mac: Registry.SimplifiedStatus.PENDING,
-          webgl: Registry.SimplifiedStatus.PENDING
+          mac: Registry.SimplifiedStatus.PENDING
         }
       },
       versions: {
         assets: {
           windows: { version: '', buildDate: '' },
-          mac: { version: '', buildDate: '' },
-          webgl: { version: '', buildDate: '' }
+          mac: { version: '', buildDate: '' }
         }
       }
     } as Registry.DbEntity),

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -112,13 +112,11 @@ export function createRegistryEntity(
     bundles: {
       assets: {
         windows: bundlesStatus,
-        mac: bundlesStatus,
-        webgl: bundlesStatus
+        mac: bundlesStatus
       },
       lods: {
         windows: bundlesStatus,
-        mac: bundlesStatus,
-        webgl: bundlesStatus
+        mac: bundlesStatus
       }
     },
     pointers: ['1000,1000'], // out of scope pointer to avoid conflicts with entities
@@ -174,8 +172,7 @@ export function createRegistryEntity(
     versions: {
       assets: {
         windows: { version: '', buildDate: '' },
-        mac: { version: '', buildDate: '' },
-        webgl: { version: '', buildDate: '' }
+        mac: { version: '', buildDate: '' }
       }
     },
     ...overrideProperties


### PR DESCRIPTION
## Summary

Upstream asset-bundle webgl conversion has been retired, so the registry no longer queues, fetches, or persists per-entity webgl bundle state. This PR finishes the cleanup.

**No behavioral change for clients.** The readiness gate ([`registry/component.ts`'s `determineRegistryStatus`](https://github.com/decentraland/asset-bundle-registry/blob/main/src/logic/registry/component.ts#L84-L113)) has always been mac+windows only and is already in production (`v2.4.1`). Entities whose mac+windows are complete were already being returned. The `webgl: pending` field in stored bundles JSONB is, and was, ignored by both the API filter and the fallback eligibility check.

## What changed

- `Bundles.assets.webgl` and `Bundles.lods.webgl` are now **optional** (existing JSONB rows still deserialize) and no longer written by default in new rows.
- `post-registry` stops fetching the webgl manifest/LODs.
- `queues-status-manager` + `key-generator` drop `'webgl'` from the platform union; `/queues/status` no longer returns `webglPendingJobs`.
- `textures-handler` and `status-handler` defensively skip `platform=webgl` events to ignore stale SQS replays — the `@dcl/schemas` event type still permits `'webgl'`, so the guard stays.
- `entity-status-fetcher` drops the dead `'webgl'`-specific URL-building branches (callers only pass `mac` / `windows`).
- Tests, mocks, OpenAPI, and docs updated to match.

## What did NOT change

- Readiness logic in [`registry/component.ts`](https://github.com/decentraland/asset-bundle-registry/blob/main/src/logic/registry/component.ts) — already mac+windows only.
- `get-active-entities` query — already filters by `[COMPLETE, FALLBACK]` and never inspected webgl.
- Existing rows in the DB — `assets.webgl` may still be present in their JSONB, but it's no longer consumed and old rows still deserialize against the new optional type.

## Test plan

- [x] `npm test` (unit) — 24 suites / 347 tests pass locally
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [ ] Integration tests (`test/integration/*`) — require local docker-compose (postgres + redis); not run in this commit
- [ ] Deploy to dev and verify `/entities/active` and `/queues/status` shapes