### PR TITLE
fix: validate deployment content-server url against a catalyst allowlist

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -18,6 +18,10 @@ REGISTRY_URL=<URL>
 ASSET_BUNDLE_ADMIN_URL=<URL>
 PROFILE_IMAGES_URL=<URL>
 
+# SSRF allowlist for the deployment event's content-server URL (issue #306).
+# Required — comma-separated content-server hosts.
+ALLOWED_CONTENT_SERVER_HOSTS=peer.decentraland.org,peer-ec1.decentraland.org,peer-ec2.decentraland.org,peer-wc1.decentraland.org,peer-eu1.decentraland.org,peer-ap1.decentraland.org,interconnected.online,peer.melonwave.com,peer.uadevops.com,peer.dclnodes.io,worlds-content-server.decentraland.org,peer-testing.decentraland.org,peer-testing-2.decentraland.org,peer.decentraland.zone,peer-ap1.decentraland.zone,worlds-content-server.decentraland.zone
+
 # Sync
 DISABLE_PROFILE_SYNC=true
 

--- a/.env.test
+++ b/.env.test
@@ -3,3 +3,4 @@ PROFILE_IMAGES_URL=https://profile-images.decentraland.zone
 DISABLE_PROFILE_SYNC=true
 CATALYST_WITH_HISTORICAL_DATA=https://peer.decentraland.zone
 SERVICE_URL=https://asset-bundle-registry.decentraland.zone
+ALLOWED_CONTENT_SERVER_HOSTS=peer.decentraland.org,peer.decentraland.zone,worlds-content-server.decentraland.org,worlds-content-server.decentraland.zone

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -1,4 +1,5 @@
 import { Entity, EntityType } from '@dcl/schemas'
+import { IFetchComponent, RequestOptions } from '@well-known-components/interfaces'
 import { ContentClient, createContentClient, createLambdasClient } from 'dcl-catalyst-client'
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 
@@ -13,8 +14,18 @@ export async function createCatalystAdapter({
 }: Pick<AppComponents, 'config' | 'logs' | 'fetch'>): Promise<ICatalystComponent> {
   const logger = logs.getLogger('catalyst-client')
 
+  // Defense-in-depth (issue #306): content fetches must NOT follow redirects — an
+  // allowlisted host could otherwise 30x to an internal resource. Treat a redirect
+  // as a hard error instead of silently following it.
+  const contentFetcher: IFetchComponent = {
+    fetch: (url, init?: RequestOptions) => fetch.fetch(url, { ...init, redirect: 'error' })
+  }
+
   const catalystLoadBalancer = await config.requireString('CATALYST_LOADBALANCER_HOST')
-  const defaultContentClient = createContentClient({ fetcher: fetch, url: ensureContentUrl(catalystLoadBalancer) })
+  const defaultContentClient = createContentClient({
+    fetcher: contentFetcher,
+    url: ensureContentUrl(catalystLoadBalancer)
+  })
 
   // We use a historical catalyst (instead of the load balancer) because some official nodes
   // have garbage-collected old profiles. The historical catalyst retains all profile data
@@ -90,7 +101,7 @@ export async function createCatalystAdapter({
   function getContentClientOrDefault(contentServerUrl?: string): ContentClient {
     const contentClientToReturn = contentServerUrl
       ? createContentClient({
-          fetcher: fetch,
+          fetcher: contentFetcher,
           url: ensureContentUrl(contentServerUrl)
         })
       : defaultContentClient

--- a/src/adapters/worlds.ts
+++ b/src/adapters/worlds.ts
@@ -27,7 +27,9 @@ export async function createWorldsAdapter({
   ): Promise<Entity | null> {
     try {
       const url = `${contentServerUrl}/contents/${entityId}`
-      const response = await fetch.fetch(url)
+      // Defense-in-depth (issue #306): do not follow redirects — an allowlisted
+      // world content server could otherwise 30x to an internal resource.
+      const response = await fetch.fetch(url, { redirect: 'error' })
 
       if (!response.ok) {
         return null

--- a/src/logic/handlers/deployment-handler.ts
+++ b/src/logic/handlers/deployment-handler.ts
@@ -2,17 +2,12 @@ import { Entity } from '@dcl/schemas'
 import { AppComponents, IEventHandlerComponent, EventHandlerName, EventHandlerResult, Registry } from '../../types'
 import { DeploymentToSqs } from '@dcl/schemas/dist/misc/deployments-to-sqs'
 import { Authenticator } from '@dcl/crypto'
+import { isAllowedContentServerUrl } from '../validation'
 
-export const createDeploymentEventHandler = ({
-  registry,
-  catalyst,
-  worlds,
-  db,
-  logs
-}: Pick<
-  AppComponents,
-  'catalyst' | 'worlds' | 'db' | 'logs' | 'registry'
->): IEventHandlerComponent<DeploymentToSqs> => {
+export const createDeploymentEventHandler = (
+  { registry, catalyst, worlds, db, logs }: Pick<AppComponents, 'catalyst' | 'worlds' | 'db' | 'logs' | 'registry'>,
+  allowedContentServerHosts: Set<string>
+): IEventHandlerComponent<DeploymentToSqs> => {
   const HANDLER_NAME = EventHandlerName.DEPLOYMENT
   const logger = logs.getLogger('deployment-handler')
 
@@ -20,6 +15,23 @@ export const createDeploymentEventHandler = ({
     handle: async (event: DeploymentToSqs): Promise<EventHandlerResult> => {
       let entity: Entity | null
       try {
+        // SSRF guard (issue #306): contentServerUrls rides in the SQS payload and
+        // the entity is fetched from it (catalyst / worlds), so reject any
+        // off-allowlist host and skip the event (ok: true — deterministic, so
+        // retrying wouldn't help). Validate EVERY entry, not just [0]: the whole
+        // array is preserved in the message. entityId isn't gated here: it only
+        // reaches parameterized SQL / cache keys, not a filesystem path or S3 key.
+        const disallowedContentServerUrl = event.contentServerUrls?.find(
+          (url) => !isAllowedContentServerUrl(url, allowedContentServerHosts)
+        )
+        if (disallowedContentServerUrl) {
+          logger.warn('Skipping deployment: a contentServerUrl is not an allowed content server (SSRF guard)', {
+            entityId: event.entity.entityId,
+            contentServerUrl: String(disallowedContentServerUrl).slice(0, 120)
+          })
+          return { ok: true, handlerName: HANDLER_NAME }
+        }
+
         const registryAlreadyExists = await db.getRegistryById(event.entity.entityId)
 
         if (registryAlreadyExists) {

--- a/src/logic/message-processor.ts
+++ b/src/logic/message-processor.ts
@@ -21,6 +21,7 @@ import { createUndeploymentEventHandler } from './handlers/undeployment-handler'
 import { createWorldUndeploymentEventHandler } from './handlers/world-undeployment-handler'
 import { createSpawnCoordinateEventHandler } from './handlers/spawn-coordinate-handler'
 import { DeploymentToSqs } from '@dcl/schemas/dist/misc/deployments-to-sqs'
+import { isAllowedContentServerUrl, parseAllowedContentServerHosts } from './validation'
 
 export async function createMessageProcessorComponent({
   catalyst,
@@ -37,6 +38,16 @@ export async function createMessageProcessorComponent({
 >): Promise<IMessageProcessorComponent> {
   const MAX_RETRIES: number = (await config.getNumber('MAX_RETRIES')) || 3
   const log = logs.getLogger('message-processor')
+
+  // Strict host allowlist for the (attacker-influenced) deployment content-server
+  // URL (issue #306). Sourced entirely from ALLOWED_CONTENT_SERVER_HOSTS (set per-env in the
+  // definitions repo) — required, with no built-in fallback list.
+  const allowedContentServerHosts = parseAllowedContentServerHosts(
+    await config.requireString('ALLOWED_CONTENT_SERVER_HOSTS')
+  )
+  if (allowedContentServerHosts.size === 0) {
+    throw new Error('ALLOWED_CONTENT_SERVER_HOSTS is set but contains no valid catalyst hosts')
+  }
   const processors: IEventHandlerComponent<
     | DeploymentToSqs
     | AssetBundleConversionManuallyQueuedEvent
@@ -45,7 +56,7 @@ export async function createMessageProcessorComponent({
     | WorldUndeploymentEvent
     | WorldSpawnCoordinateSetEvent
   >[] = [
-    createDeploymentEventHandler({ catalyst, worlds, registry, db, logs }),
+    createDeploymentEventHandler({ catalyst, worlds, registry, db, logs }, allowedContentServerHosts),
     createTexturesEventHandler({
       db,
       logs,
@@ -69,6 +80,25 @@ export async function createMessageProcessorComponent({
 
     if (retryData.attempt >= MAX_RETRIES) {
       log.warn('Max retries reached for the message, will not retry', { message })
+      return {
+        ok: true,
+        failedHandlers: []
+      }
+    }
+
+    // SSRF / poisoned-message guard at the dispatch level (issue #306): a
+    // deployment carrying an off-allowlist content-server host is dropped before
+    // ANY handler runs. The deployment handler already skips it, but other
+    // handlers (e.g. status) would otherwise still act on it and leave an
+    // orphaned queue-status entry. Drop it (ok, no retry) — it's deterministic.
+    const disallowedContentServerUrl = Array.isArray(message?.contentServerUrls)
+      ? message.contentServerUrls.find((url: string) => !isAllowedContentServerUrl(url, allowedContentServerHosts))
+      : undefined
+    if (disallowedContentServerUrl) {
+      log.warn('Dropping message: a contentServerUrl is not an allowed content server (SSRF/allowlist guard)', {
+        entityId: message?.entity?.entityId,
+        contentServerUrl: String(disallowedContentServerUrl).slice(0, 120)
+      })
       return {
         ok: true,
         failedHandlers: []

--- a/src/logic/validation.ts
+++ b/src/logic/validation.ts
@@ -1,0 +1,56 @@
+/**
+ * SSRF guard for deployment events the registry consumes. Mirrors the
+ * asset-bundle-converter (issue #306): the deployment event's
+ * `contentServerUrls[0]` is attacker-influenced and the registry fetches the
+ * entity from it (catalyst / worlds), so it is pinned to a strict HTTPS +
+ * exact-host allowlist. (entityId is not gated here — in the registry it only
+ * reaches parameterized SQL / cache keys, not a filesystem path or S3 key.)
+ *
+ * The allowlist is sourced entirely from the `ALLOWED_CONTENT_SERVER_HOSTS` env var (set
+ * per-environment in the `definitions` repo) — there is no built-in default.
+ */
+
+/**
+ * Normalize one allowlist entry to a bare lowercase hostname. Accepts a bare
+ * host or a full URL; returns undefined for blank/unparseable entries.
+ */
+function normalizeContentServerHost(entry: string): string | undefined {
+  const trimmed = entry.trim().toLowerCase()
+  if (trimmed.length === 0) return undefined
+  if (trimmed.includes('/')) {
+    try {
+      const withScheme = /^[a-z][a-z0-9+.-]*:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`
+      const host = new URL(withScheme).hostname.replace(/^\[|\]$/g, '').toLowerCase()
+      return host.length > 0 ? host : undefined
+    } catch {
+      return undefined
+    }
+  }
+  return trimmed
+}
+
+/**
+ * Parse the `ALLOWED_CONTENT_SERVER_HOSTS` env var (comma-separated catalyst hosts) into a
+ * Set of normalized hostnames. No built-in fallback list — the caller requires
+ * the var and rejects an empty result.
+ */
+export function parseAllowedContentServerHosts(raw: string | undefined): Set<string> {
+  const hosts = (raw ?? '')
+    .split(',')
+    .map(normalizeContentServerHost)
+    .filter((h): h is string => h !== undefined)
+  return new Set(hosts)
+}
+
+/** True when `raw` is an HTTPS URL whose host is exactly on the allowlist. */
+export function isAllowedContentServerUrl(raw: string, allowedHosts: Set<string>): boolean {
+  let u: URL
+  try {
+    u = new URL(raw)
+  } catch {
+    return false
+  }
+  if (u.protocol !== 'https:') return false
+  const host = u.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  return allowedHosts.has(host)
+}

--- a/test/unit/logic/handlers/deployment-handler.spec.ts
+++ b/test/unit/logic/handlers/deployment-handler.spec.ts
@@ -2,6 +2,7 @@ import { Entity, EntityType } from '@dcl/schemas'
 import { AuthLinkType } from '@dcl/crypto'
 import { DeploymentToSqs } from '@dcl/schemas/dist/misc/deployments-to-sqs'
 import { createDeploymentEventHandler } from '../../../../src/logic/handlers/deployment-handler'
+import { parseAllowedContentServerHosts } from '../../../../src/logic/validation'
 import { EventHandlerName, Registry } from '../../../../src/types'
 import { createDbMockComponent } from '../../mocks/db'
 import { createLogMockComponent } from '../../mocks/logs'
@@ -10,6 +11,10 @@ import { createWorldsMockComponent } from '../../mocks/worlds'
 import { createRegistryMockComponent } from '../../mocks/registry'
 
 describe('when handling deployment events', () => {
+  const allowedContentServerHosts = parseAllowedContentServerHosts(
+    'peer.decentraland.org, worlds-content-server.decentraland.org'
+  )
+
   const createDeploymentEvent = (entityId: string, contentServerUrls?: string[]): DeploymentToSqs => ({
     entity: {
       entityId,
@@ -49,7 +54,7 @@ describe('when handling deployment events', () => {
       catalyst = createCatalystMockComponent()
       worlds = createWorldsMockComponent()
       registry = createRegistryMockComponent()
-      handler = createDeploymentEventHandler({ logs, db, catalyst, worlds, registry })
+      handler = createDeploymentEventHandler({ logs, db, catalyst, worlds, registry }, allowedContentServerHosts)
     })
 
     afterEach(() => {
@@ -95,7 +100,7 @@ describe('when handling deployment events', () => {
       catalyst = createCatalystMockComponent()
       worlds = createWorldsMockComponent()
       registry = createRegistryMockComponent()
-      handler = createDeploymentEventHandler({ logs, db, catalyst, worlds, registry })
+      handler = createDeploymentEventHandler({ logs, db, catalyst, worlds, registry }, allowedContentServerHosts)
     })
 
     afterEach(() => {
@@ -208,6 +213,28 @@ describe('when handling deployment events', () => {
       })
     })
 
+    describe('and the deployment has an empty contentServerUrls array', () => {
+      let event: DeploymentToSqs
+      let entity: Entity
+
+      beforeEach(() => {
+        event = createDeploymentEvent('genesis-entity-id', [])
+        entity = createEntity({ id: 'genesis-entity-id', pointers: ['0,0'] })
+        db.getRegistryById.mockResolvedValue(null)
+        worlds.isWorldDeployment.mockReturnValue(false)
+        catalyst.getEntityById.mockResolvedValue(entity)
+        registry.persistAndRotateStates.mockResolvedValue(undefined as any)
+      })
+
+      it('should not reject it and should fetch from the default catalyst with no override', async () => {
+        await handler.handle(event)
+
+        expect(catalyst.getEntityById).toHaveBeenCalledWith('genesis-entity-id', {
+          overrideContentServerUrl: undefined
+        })
+      })
+    })
+
     describe('and the deployment is a Genesis City scene with a content server URL', () => {
       let event: DeploymentToSqs
       let entity: Entity
@@ -280,6 +307,47 @@ describe('when handling deployment events', () => {
 
         expect(result.ok).toBe(true)
         expect(result.handlerName).toBe(EventHandlerName.DEPLOYMENT)
+      })
+    })
+
+    describe('and the deployment points at a content server that is not an allowed catalyst', () => {
+      let event: DeploymentToSqs
+
+      beforeEach(() => {
+        event = createDeploymentEvent('genesis-entity-id', ['https://169.254.169.254/latest/meta-data/'])
+        db.getRegistryById.mockResolvedValue(null)
+        worlds.isWorldDeployment.mockReturnValue(false)
+      })
+
+      it('should skip the event without fetching the entity (SSRF guard)', async () => {
+        const result = await handler.handle(event)
+
+        expect(result.ok).toBe(true)
+        expect(result.handlerName).toBe(EventHandlerName.DEPLOYMENT)
+        expect(catalyst.getEntityById).not.toHaveBeenCalled()
+        expect(registry.persistAndRotateStates).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and a later contentServerUrl entry is not an allowed catalyst', () => {
+      let event: DeploymentToSqs
+
+      beforeEach(() => {
+        // First entry is allowlisted, second is not — every entry must be checked.
+        event = createDeploymentEvent('genesis-entity-id', [
+          'https://peer.decentraland.org/content',
+          'https://evil.internal/ssrf'
+        ])
+        db.getRegistryById.mockResolvedValue(null)
+        worlds.isWorldDeployment.mockReturnValue(false)
+      })
+
+      it('should skip the event even though the first URL is allowlisted', async () => {
+        const result = await handler.handle(event)
+
+        expect(result.ok).toBe(true)
+        expect(catalyst.getEntityById).not.toHaveBeenCalled()
+        expect(registry.persistAndRotateStates).not.toHaveBeenCalled()
       })
     })
 

--- a/test/unit/logic/message-processor.spec.ts
+++ b/test/unit/logic/message-processor.spec.ts
@@ -22,6 +22,7 @@ describe('message processor', () => {
   const logs = createLogMockComponent()
   const config = createConfigMockComponent()
   ;(config.getNumber as jest.Mock).mockResolvedValue(3) // MAX_RETRIES = 3
+  ;(config.requireString as jest.Mock).mockResolvedValue('peer.decentraland.org') // ALLOWED_CONTENT_SERVER_HOSTS
 
   // Create mock handlers
   const deploymentHandler: IEventHandlerComponent<DeploymentToSqs> = {
@@ -245,6 +246,24 @@ describe('message processor', () => {
         expect(texturesHandler.handle).not.toHaveBeenCalled()
         expect(statusHandler.handle).not.toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('when the message is a deployment with an off-allowlist content-server host', () => {
+    it('should drop the message before any handler runs, so no handler creates an orphaned entry', async () => {
+      const message = {
+        entity: { entityId: '123', authChain: [] },
+        contentServerUrls: ['https://evil.internal/ssrf']
+      }
+
+      const processor = await createMessageProcessorComponent(mockComponents)
+
+      const result = await processor.process(message)
+
+      expect(result.ok).toBe(true)
+      expect(deploymentHandler.handle).not.toHaveBeenCalled()
+      expect(texturesHandler.handle).not.toHaveBeenCalled()
+      expect(statusHandler.handle).not.toHaveBeenCalled()
     })
   })
 })

--- a/test/unit/logic/validation.spec.ts
+++ b/test/unit/logic/validation.spec.ts
@@ -1,0 +1,95 @@
+import { isAllowedContentServerUrl, parseAllowedContentServerHosts } from '../../../src/logic/validation'
+
+describe('when parsing the ALLOWED_CONTENT_SERVER_HOSTS value', () => {
+  let result: Set<string>
+
+  describe('and the value is undefined', () => {
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts(undefined)
+    })
+
+    it('should produce an empty set, since there is no built-in default', () => {
+      expect(result.size).toBe(0)
+    })
+  })
+
+  describe('and the entries are uppercased or full URLs', () => {
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('PEER.example.org, https://peer-2.example.org/content')
+    })
+
+    it('should lowercase and normalize each entry down to its hostname', () => {
+      expect(result).toEqual(new Set(['peer.example.org', 'peer-2.example.org']))
+    })
+  })
+
+  describe('and the value contains only separators and whitespace', () => {
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts(' , ,')
+    })
+
+    it('should produce an empty set', () => {
+      expect(result.size).toBe(0)
+    })
+  })
+})
+
+describe('when validating a content-server URL against the allowlist', () => {
+  let allowedHosts: Set<string>
+  let result: boolean
+
+  beforeEach(() => {
+    allowedHosts = parseAllowedContentServerHosts('peer.decentraland.org, worlds-content-server.decentraland.org')
+  })
+
+  describe('and the URL is an HTTPS host on the allowlist', () => {
+    beforeEach(() => {
+      result = isAllowedContentServerUrl('https://peer.decentraland.org/content', allowedHosts)
+    })
+
+    it('should accept it', () => {
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('and the host is not on the allowlist', () => {
+    beforeEach(() => {
+      result = isAllowedContentServerUrl('https://evil.example.com/content', allowedHosts)
+    })
+
+    it('should reject it', () => {
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('and the URL points at the cloud metadata IP', () => {
+    beforeEach(() => {
+      result = isAllowedContentServerUrl('https://169.254.169.254/latest/meta-data/', allowedHosts)
+    })
+
+    it('should reject it, since no IP literal is on the allowlist', () => {
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('and an allowlisted host is requested over plain HTTP', () => {
+    beforeEach(() => {
+      result = isAllowedContentServerUrl('http://peer.decentraland.org/content', allowedHosts)
+    })
+
+    it('should reject it, since content servers must be HTTPS', () => {
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('and the allowlist is empty', () => {
+    beforeEach(() => {
+      allowedHosts = new Set()
+      result = isAllowedContentServerUrl('https://peer.decentraland.org/content', allowedHosts)
+    })
+
+    it('should reject every URL', () => {
+      expect(result).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
the deployment event's `contentServerUrls[0]` rides in the (attacker-influenced) sqs payload, and the deployment handler fetches the entity from it (`catalyst.getEntityById` / `worlds.getWorld`) — the same ssrf surface as asset-bundle-converter issue #306.

## what
- the deployment handler now skips any event whose content-server url is not an https host on the catalyst allowlist (returns ok so it isn't retried — the failure is deterministic).
- the allowlist is read once in the message processor from the required `ALLOWED_CONTENT_SERVER_HOSTS` env var (no built-in default; set per-env in the `definitions` repo) and passed into the handler.
- `src/logic/validation.ts` holds the shared helpers.

## scope note
- entityId is intentionally **not** gated here: in the registry it only reaches parameterized sql / cache keys, not a filesystem path or s3 key, so the path-traversal guard that applies in the converter / deployments-to-sqs doesn't apply.

## tests
- new `test/unit/logic/validation.spec.ts`; an ssrf-rejection test in the deployment-handler spec. unit suites green (29).

companion to decentraland/asset-bundle-converter#307.


## addressed review follow-ups
- **poisoned messages dropped at dispatch level**: `status-handler.canHandle` also matches `DeploymentToSqs`, so a poisoned message the deployment handler skipped would still get a `markAsQueued` (orphaned, never-resolving queue-status entry). the message processor now drops any deployment with an off-allowlist content-server host *before* dispatching to any handler. the deployment-handler guard stays as defense-in-depth.
- **content fetches no longer follow redirects** (defense-in-depth): an allowlisted host could otherwise 30x to an internal resource. the catalyst content client and the worlds fetch now use `redirect: 'error'`. (the lambdas/profiles path is unchanged — separate feature, trusted host.)
- **explicit empty-array test**: added a `contentServerUrls: []` case confirming it isn't rejected and falls back to the default catalyst.

full unit suite green (360 tests).
