### PR TITLE
fix(auth): upgrade crypto middleware validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@dcl/catalyst-storage": "^4.6.1",
     "@dcl/core-commons": "^0.10.1",
     "@dcl/crypto": "^3.7.0",
-    "@dcl/crypto-middleware": "^5.0.0",
+    "@dcl/crypto-middleware": "^5.1.0",
     "@dcl/features-component": "^1.0.2",
     "@dcl/fetch-component": "^1.1.1",
     "@dcl/http-commons": "^2.0.0",

--- a/test/integration/canonical-signer.spec.ts
+++ b/test/integration/canonical-signer.spec.ts
@@ -1,0 +1,66 @@
+import { Authenticator } from '@dcl/crypto'
+import { AUTH_METADATA_HEADER } from '@dcl/crypto-middleware'
+import { test } from '../components'
+import { createRequestMaker, getAuthHeaders, getIdentity, Identity } from '../utils'
+
+const SIGNED_METADATA = { signer: 'decentraland-kernel-scene' }
+const DELIVERED_METADATA = JSON.stringify({ signer: 'Decentraland-Kernel-Scene' })
+
+test('GET /entities/status with a scene signer', function ({ components }) {
+  let identity: Identity
+  let fetchLocally: any
+
+  beforeAll(async function () {
+    const { makeLocalRequest } = createRequestMaker(components)
+    fetchLocally = makeLocalRequest
+  })
+
+  beforeEach(async function () {
+    identity = await getIdentity()
+  })
+
+  it('should reject a request that signed the canonical signer but delivered a mixed-case spelling', async function () {
+    // The canonical payload is lowercased before signing, so a metadata value differing only in
+    // case shares the signature. Overwriting the header after signing leaves the request genuinely
+    // authentic while reading differently to any case-sensitive comparison downstream. This is the
+    // attack, not a mock: nothing here weakens the signature.
+    const headers = getAuthHeaders('GET', '/entities/status', SIGNED_METADATA, (payload) =>
+      Authenticator.signPayload(
+        {
+          ephemeralIdentity: identity.ephemeralIdentity,
+          expiration: new Date(),
+          authChain: identity.authChain.authChain
+        },
+        payload
+      )
+    )
+    headers[AUTH_METADATA_HEADER] = DELIVERED_METADATA
+
+    const response = await components.localFetch.fetch('/entities/status', { method: 'GET', headers })
+    const parsedResponse = await response.json()
+
+    // Without this guard the mixed-case spelling fails the strict `!== 'decentraland-kernel-scene'`
+    // check in routes.ts, so the scene request is read as a directly user-signed one and served.
+    expect(response.status).toBe(400)
+    // The raw metadata is echoed back truncated at 64 characters, so match the prefix.
+    expect(parsedResponse.error).toMatch(/^Invalid chain metadata: /)
+  })
+
+  it('should reject a request that delivers the canonical signer exactly as signed', async function () {
+    const response = await fetchLocally('GET', '/entities/status', identity, undefined, SIGNED_METADATA)
+    const parsedResponse = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(parsedResponse.error).toMatch(/^Invalid metadata content: /)
+  })
+
+  it('should authenticate a request carrying no signer at all', async function () {
+    const response = await fetchLocally('GET', '/entities/status', identity)
+    const parsedResponse = await response.json()
+
+    // Ordinary user traffic must be untouched by the guard: this gets all the way to the handler,
+    // which reports no registries for this freshly generated identity.
+    expect(response.status).toBe(200)
+    expect(parsedResponse).toEqual([])
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     "@dcl/core-commons" "^0.10.0"
     "@dcl/crypto" "3.7.0"
 
-"@dcl/crypto-middleware@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@dcl/crypto-middleware/-/crypto-middleware-5.0.0.tgz#3237b3888cac37e0920de8ee1d3fad9b54a77424"
-  integrity sha512-MIy5oRsTy8AujEef6MDaObJM04zZqKDVF9FlWz6aBxjr1kU7jjSDPxHRLIcXC4ECCCWpugpd6A8gwsE3TVhRhw==
+"@dcl/crypto-middleware@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/crypto-middleware/-/crypto-middleware-5.1.0.tgz#382bc899d4f9cb07541baa7d35a4322e5810ea77"
+  integrity sha512-aiG/aInYDgL5Er+KStaIqjOmGGLlmIHSRlcAK5Jzyn+wiPU/kYiQIpMDyaIsrZ0om9HOi0M6lnqcR7ZVNpj4bA==
   dependencies:
     "@dcl/core-commons" "^0.10.0"
     "@dcl/crypto" "3.7.0"


### PR DESCRIPTION
## Summary

- upgrade `@dcl/crypto-middleware` to `^5.1.0`
- add a canonical-signer regression test that signs canonical scene metadata and delivers a mixed-case spelling
- retain a normal signed-user request as a positive control

## Validation

- `yarn build`
- `yarn lint:check`
- `prettier --check 'src/**/*.ts' 'test/**/*.ts'`
- `yarn test test/integration/canonical-signer.spec.ts --runInBand`
- `yarn test --runInBand`
