### PR TITLE
fix: derive profile identity fields from the entity pointer

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -897,13 +897,16 @@ components:
       properties:
         pointer:
           type: string
-          description: Ethereum address of the profile owner
+          description: Requested profile pointer, either an Ethereum address or numeric default profile name
         hasClaimedName:
           type: boolean
           description: Whether the user has claimed a unique Decentraland name
         name:
           type: string
           description: Display name for the profile
+        nameColor:
+          type: object
+          description: Optional profile name color configuration
         thumbnailUrl:
           type: string
           description: URL to the profile's face thumbnail image

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -310,7 +310,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ProfileDTO'
         '400':
-          description: The ids property is missing, malformed or exceeds the request limits
+          description: The ids property is missing or malformed
           content:
             application/json:
               schema:
@@ -343,7 +343,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ProfileMetadataDTO'
         '400':
-          description: The ids property is missing, malformed or exceeds the request limits
+          description: The ids property is missing or malformed
           content:
             application/json:
               schema:
@@ -814,13 +814,9 @@ components:
           items:
             type: string
             minLength: 1
-          maxItems: 500
           description: |
             Ethereum addresses to fetch profiles for. Empty arrays are accepted and return an empty
             response.
-
-            At most 500 addresses per request; exceeding it is rejected rather than answered with a
-            partial result.
       required:
         - ids
     ProfileDTO:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -815,8 +815,15 @@ components:
             type: string
             minLength: 1
           description: |
-            Ethereum addresses to fetch profiles for. Empty arrays are accepted and return an empty
-            response.
+            Profile pointers to fetch. A pointer is either an Ethereum address or, for default
+            profiles, a name such as `default5`.
+
+            An address resolves from the cache, the database, or a catalyst lookup. A default profile
+            name resolves from the cache or the database only: a catalyst response reports that
+            profile's deployer address rather than the name, so it cannot be attributed to the name
+            it was asked for.
+
+            Empty arrays are accepted and return an empty response.
       required:
         - ids
     ProfileDTO:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -816,13 +816,11 @@ components:
             minLength: 1
           maxItems: 500
           description: |
-            Profile pointers to fetch. A pointer is either an Ethereum address or, for default
-            profiles, a numeric name such as `default5`. Ids that are neither are ignored. Empty
-            arrays are accepted and return an empty response.
+            Ethereum addresses to fetch profiles for. Empty arrays are accepted and return an empty
+            response.
 
-            At most 500 pointers per request, of which at most 25 may be numeric default profile names:
-            those cannot be batched upstream, so each one costs its own lookup. Exceeding either
-            limit is rejected rather than answered with a partial result.
+            At most 500 addresses per request; exceeding it is rejected rather than answered with a
+            partial result.
       required:
         - ids
     ProfileDTO:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -814,13 +814,13 @@ components:
           items:
             type: string
             minLength: 1
-          minItems: 1
           maxItems: 500
           description: |
             Profile pointers to fetch. A pointer is either an Ethereum address or, for default
-            profiles, a name such as `default5`. Ids that are neither are ignored.
+            profiles, a numeric name such as `default5`. Ids that are neither are ignored. Empty
+            arrays are accepted and return an empty response.
 
-            At most 500 pointers per request, of which at most 25 may be default profile names:
+            At most 500 pointers per request, of which at most 25 may be numeric default profile names:
             those cannot be batched upstream, so each one costs its own lookup. Exceeding either
             limit is rejected rather than answered with a partial result.
       required:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3,32 +3,32 @@ info:
   title: Asset Bundle Registry API
   description: |
     ## Overview
-    
+
     The Asset Bundle Registry is a proxy service that manages the availability of converted Unity Asset Bundles for Decentraland content. It acts as an intermediary between the Unity Client and the content network hosted in the Catalyst servers.
-    
+
     ### What are Unity Asset Bundles?
-    
+
     Unity Asset Bundles are optimized, pre-compiled packages of 3D assets used in Decentraland to improve performance. Instead of loading raw GLTF models at runtime, scenes and wearables are converted into Asset Bundles by the Asset Bundle Converter service, which loads scene assets, re-imports GLTF models, and packages them into optimized bundles stored on a CDN.
-    
+
     ### How the Registry Works
-    
+
     The Asset Bundle Registry acts as an intelligent proxy between clients and the Catalyst content servers:
-    
+
     1. **Content Upload**: When new content (scenes, wearables, etc.) is uploaded to a Catalyst server, it triggers the Asset Bundle Converter to process the assets.
-    
+
     2. **Availability Management**: While the new content is being converted (which can take time), the registry continues to serve the **previous version** of the asset bundle for that pointer.
-    
+
     3. **Seamless Transitions**: This ensures that when clients request a scene or wearable, there is always something to display in-world, preventing broken experiences during content updates.
-    
+
     4. **Pointer-based Queries**: Clients query the registry by pointers (e.g., scene coordinates like "-53,71" or wearable URNs) to get the latest **available** and **ready** asset bundle, not necessarily the latest uploaded content.
-    
+
     ### Key Features
-    
+
     - **Always Available**: Returns the most recent successfully converted asset bundle
     - **Processing Status**: Track conversion progress of new content
     - **Multi-version Support**: Handles different Asset Bundle versions (v4, v5, etc.) based on Unity version and material changes
     - **Queue Monitoring**: Provides visibility into conversion queue status
-    
+
     The registry works in conjunction with the Asset Bundle Converter service and the Catalyst content servers to provide a reliable, performant content delivery system for Decentraland.
   version: 1.0.0
   contact:
@@ -95,11 +95,11 @@ paths:
       description: |
         Returns the currently active (ready-to-use) entities for the given pointers. This is the primary endpoint 
         for clients to query which asset bundles are available for display.
-        
+
         **Pointers** are unique identifiers for content locations:
         - For scenes: coordinates like "-53,71" or "-100,-50"
         - For wearables: URNs like "urn:decentraland:matic:collections-v2:0x..."
-        
+
         The response includes entities with their associated asset bundle content that are **ready for use**. 
         If new content is currently being processed for a pointer, this endpoint will return the previous 
         successfully converted version, ensuring clients always have something to render.
@@ -133,10 +133,10 @@ paths:
       summary: Get entity status by ID
       description: |
         Returns the current processing status of a specific entity by its ID (typically a content identifier/CID).
-        
+
         Use this endpoint to check whether an entity has been successfully converted to an asset bundle, 
         is currently being processed, or is inactive.
-        
+
         **Status values:**
         - `active`: Entity has been successfully converted and is ready for use
         - `processing`: Entity is currently being converted by the Asset Bundle Converter
@@ -171,7 +171,7 @@ paths:
       description: |
         Returns the processing status of multiple entities in a single request. This endpoint requires 
         authenticated access via Decentraland's signed fetch mechanism.
-        
+
         Useful for batch checking the conversion status of multiple pieces of content (scenes, wearables, etc.) 
         to determine which are ready for use and which are still being processed.
       operationId: getEntitiesStatus
@@ -249,13 +249,13 @@ paths:
       summary: Get queue status information
       description: |
         Returns status information about the internal processing queues that handle asset bundle conversion requests.
-        
+
         This endpoint provides visibility into:
         - Number of entities pending conversion
         - Number of entities currently being processed
         - Number of successfully completed conversions
         - Number of failed conversions
-        
+
         Useful for monitoring system load and identifying potential bottlenecks in the asset bundle conversion pipeline.
       operationId: getQueuesStatus
       security: []
@@ -282,9 +282,9 @@ paths:
     post:
       tags:
         - Profiles
-      summary: Get profiles by addresses
+      summary: Get profiles by pointer
       description: |
-        Returns validated Catalyst profiles for the given Ethereum addresses. Profiles include
+        Returns validated Catalyst profiles for the given pointers. Profiles include
         avatar information, names, wearables, and snapshot URLs.
 
         The service maintains a multi-layer cache (memory and database) for fast profile retrieval
@@ -309,13 +309,19 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ProfileDTO'
+        '400':
+          description: The ids property is missing, malformed or exceeds the request limits
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /profiles/metadata:
     post:
       tags:
         - Profiles
-      summary: Get profile metadata by addresses
+      summary: Get profile metadata by pointer
       description: |
-        Returns lightweight metadata for profiles at the given Ethereum addresses.
+        Returns lightweight metadata for profiles at the given pointers.
         This endpoint returns only essential profile information (name, claimed name status,
         thumbnail URL) without full avatar details, making it suitable for displaying
         profile cards or lists.
@@ -336,6 +342,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ProfileMetadataDTO'
+        '400':
+          description: The ids property is missing, malformed or exceeds the request limits
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /registry:
     post:
       tags:
@@ -801,7 +813,16 @@ components:
           type: array
           items:
             type: string
-          description: List of Ethereum addresses to fetch profiles for
+            minLength: 1
+          minItems: 1
+          maxItems: 500
+          description: |
+            Profile pointers to fetch. A pointer is either an Ethereum address or, for default
+            profiles, a name such as `default5`. Ids that are neither are ignored.
+
+            At most 500 pointers per request, of which at most 25 may be default profile names:
+            those cannot be batched upstream, so each one costs its own lookup. Exceeding either
+            limit is rejected rather than answered with a partial result.
       required:
         - ids
     ProfileDTO:

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -1,13 +1,12 @@
-import { Entity, EntityType, EthAddress } from '@dcl/schemas'
+import { Entity, EntityType } from '@dcl/schemas'
 import { IFetchComponent, RequestOptions } from '@dcl/core-commons'
 import { ContentClient, createContentClient, createLambdasClient } from 'dcl-catalyst-client'
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 
 import { AppComponents, ICatalystComponent, CatalystFetchOptions } from '../types'
+import { isAddressPointer, isDefaultProfilePointer } from '../utils/pointers'
 
 const ENTITY_ID_FROM_SNAPSHOT_REGEX = /\/entities\/([^/]+)\//
-const DEFAULT_PROFILE_POINTER_PREFIX = 'default'
-const MAX_NAME_POINTER_LOOKUPS = 25
 const NAME_POINTER_LOOKUP_CONCURRENCY = 5
 
 export async function createCatalystAdapter({
@@ -241,18 +240,11 @@ export async function createCatalystAdapter({
   async function getProfilesByNamePointers(pointers: string[]): Promise<Map<string, Profile>> {
     const matched = new Map<string, Profile>()
 
-    // Each of these costs its own request, so the amount of them is bounded
-    const lookups = pointers.slice(0, MAX_NAME_POINTER_LOOKUPS)
-
-    if (lookups.length < pointers.length) {
-      logger.warn('Too many name pointers requested, ignoring the excess', {
-        requested: pointers.length,
-        lookedUp: lookups.length
-      })
-    }
-
-    for (let i = 0; i < lookups.length; i += NAME_POINTER_LOOKUP_CONCURRENCY) {
-      const chunk = lookups.slice(i, i + NAME_POINTER_LOOKUP_CONCURRENCY)
+    // Each of these costs its own request, so they are spread over bounded chunks rather than
+    // fired at once. Every pointer is looked up: a partial result is indistinguishable from a
+    // missing profile to the caller.
+    for (let i = 0; i < pointers.length; i += NAME_POINTER_LOOKUP_CONCURRENCY) {
+      const chunk = pointers.slice(i, i + NAME_POINTER_LOOKUP_CONCURRENCY)
       const profiles = await Promise.all(chunk.map((pointer) => getProfileByNamePointer(pointer)))
 
       chunk.forEach((pointer, index) => {
@@ -280,12 +272,9 @@ export async function createCatalystAdapter({
     let ignored = 0
 
     for (const pointer of pointers) {
-      // Validated on the normalized form, since every layer keys by the lowercased pointer
-      const isAddress: boolean = EthAddress.validate(pointer.toLowerCase())
-
-      if (isAddress) {
+      if (isAddressPointer(pointer)) {
         addressPointers.push(pointer)
-      } else if (pointer.toLowerCase().startsWith(DEFAULT_PROFILE_POINTER_PREFIX)) {
+      } else if (isDefaultProfilePointer(pointer)) {
         namePointers.push(pointer)
       } else {
         // Neither an address nor a default profile name, so it cannot match any profile

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -4,10 +4,8 @@ import { ContentClient, createContentClient, createLambdasClient } from 'dcl-cat
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 
 import { AppComponents, ICatalystComponent, CatalystFetchOptions } from '../types'
-import { isAddressPointer, isDefaultProfilePointer } from '../utils/pointers'
 
 const ENTITY_ID_FROM_SNAPSHOT_REGEX = /\/entities\/([^/]+)\//
-const NAME_POINTER_LOOKUP_CONCURRENCY = 5
 
 export async function createCatalystAdapter({
   config,
@@ -39,11 +37,13 @@ export async function createCatalystAdapter({
     return match ? match[1] : null
   }
 
-  function convertLambdasProfileToEntity(profile: Profile, pointer: string): Entity | null {
+  function convertLambdasProfileToEntity(profile: Profile): Entity | null {
     const avatar = profile.avatars?.[0]
-    if (!avatar) {
+    if (!avatar?.ethAddress) {
       return null
     }
+
+    const pointer = avatar.ethAddress
 
     const snapshotUrl = avatar.avatar?.snapshots?.body || avatar.avatar?.snapshots?.face256
     if (!snapshotUrl) {
@@ -61,7 +61,6 @@ export async function createCatalystAdapter({
       version: 'v3',
       id: entityId,
       type: EntityType.PROFILE,
-      // Supplied by the caller so the entity is keyed by the pointer it was requested for
       pointers: [pointer.toLowerCase()],
       timestamp: profile.timestamp!,
       content: [],
@@ -166,75 +165,6 @@ export async function createCatalystAdapter({
     return contentJson as Entity
   }
 
-  async function getProfilesByAddress(pointers: string[]): Promise<Map<string, Profile>> {
-    const matched = new Map<string, Profile>()
-
-    if (pointers.length === 0) {
-      return matched
-    }
-
-    try {
-      const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: pointers })
-
-      // Lambdas serves the identity of an address profile from the entity pointer, so the address in
-      // the response is what the profile was requested for
-      for (const profile of profiles) {
-        const address = profile.avatars?.[0]?.ethAddress?.toLowerCase()
-
-        if (address) {
-          matched.set(address, profile)
-        }
-      }
-    } catch (error: any) {
-      logger.error('Error fetching profiles from historical catalyst lambdas', {
-        error: error?.message || 'Unknown error',
-        count: pointers.length
-      })
-    }
-
-    return matched
-  }
-
-  async function getProfileByNamePointer(pointer: string): Promise<Profile | null> {
-    try {
-      const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: [pointer] })
-
-      // Asked for one pointer, so anything other than a single profile cannot be correlated
-      if (profiles.length !== 1 || !profiles[0].avatars?.[0]) {
-        return null
-      }
-
-      return profiles[0]
-    } catch (error: any) {
-      logger.error('Error fetching profile from historical catalyst lambdas', {
-        pointer,
-        error: error?.message || 'Unknown error'
-      })
-      return null
-    }
-  }
-
-  async function getProfilesByNamePointers(pointers: string[]): Promise<Map<string, Profile>> {
-    const matched = new Map<string, Profile>()
-
-    // Each of these costs its own request, so they are spread over bounded chunks rather than
-    // fired at once. Every pointer is looked up: a partial result is indistinguishable from a
-    // missing profile to the caller.
-    for (let i = 0; i < pointers.length; i += NAME_POINTER_LOOKUP_CONCURRENCY) {
-      const chunk = pointers.slice(i, i + NAME_POINTER_LOOKUP_CONCURRENCY)
-      const profiles = await Promise.all(chunk.map((pointer) => getProfileByNamePointer(pointer)))
-
-      chunk.forEach((pointer, index) => {
-        const profile = profiles[index]
-        if (profile) {
-          matched.set(pointer.toLowerCase(), profile)
-        }
-      })
-    }
-
-    return matched
-  }
-
   async function getProfiles(pointers: string[]): Promise<Map<string, Profile>> {
     const profilesByPointer = new Map<string, Profile>()
 
@@ -242,34 +172,23 @@ export async function createCatalystAdapter({
       return profilesByPointer
     }
 
-    // Name pointers (default profiles) carry an unrelated address in their metadata, and every
-    // default profile shares the same one, so they can only be correlated one request at a time
-    const addressPointers: string[] = []
-    const namePointers: string[] = []
-    let ignored = 0
+    try {
+      const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: pointers })
 
-    for (const pointer of pointers) {
-      if (isAddressPointer(pointer)) {
-        addressPointers.push(pointer)
-      } else if (isDefaultProfilePointer(pointer)) {
-        namePointers.push(pointer)
-      } else {
-        // Neither an address nor a default profile name, so it cannot match any profile
-        ignored++
+      // Lambdas serves an address profile's identity from the entity pointer, so the address it
+      // reports is the pointer the profile was requested for
+      for (const profile of profiles) {
+        const address = profile.avatars?.[0]?.ethAddress?.toLowerCase()
+
+        if (address) {
+          profilesByPointer.set(address, profile)
+        }
       }
-    }
-
-    if (ignored > 0) {
-      logger.debug('Ignored pointers that are neither an address nor a default profile name', { ignored })
-    }
-
-    const [byAddress, byName] = await Promise.all([
-      getProfilesByAddress(addressPointers),
-      getProfilesByNamePointers(namePointers)
-    ])
-
-    for (const [pointer, profile] of [...byAddress, ...byName]) {
-      profilesByPointer.set(pointer, profile)
+    } catch (error: any) {
+      logger.error('Error fetching profiles from historical catalyst lambdas', {
+        error: error?.message || 'Unknown error',
+        count: pointers.length
+      })
     }
 
     return profilesByPointer

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -6,6 +6,9 @@ import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 import { AppComponents, ICatalystComponent, CatalystFetchOptions } from '../types'
 
 const ENTITY_ID_FROM_SNAPSHOT_REGEX = /\/entities\/([^/]+)\//
+const DEFAULT_PROFILE_POINTER_PREFIX = 'default'
+const MAX_NAME_POINTER_LOOKUPS = 25
+const NAME_POINTER_LOOKUP_CONCURRENCY = 5
 
 export async function createCatalystAdapter({
   config,
@@ -235,6 +238,34 @@ export async function createCatalystAdapter({
     }
   }
 
+  async function getProfilesByNamePointers(pointers: string[]): Promise<Map<string, Profile>> {
+    const matched = new Map<string, Profile>()
+
+    // Each of these costs its own request, so the amount of them is bounded
+    const lookups = pointers.slice(0, MAX_NAME_POINTER_LOOKUPS)
+
+    if (lookups.length < pointers.length) {
+      logger.warn('Too many name pointers requested, ignoring the excess', {
+        requested: pointers.length,
+        lookedUp: lookups.length
+      })
+    }
+
+    for (let i = 0; i < lookups.length; i += NAME_POINTER_LOOKUP_CONCURRENCY) {
+      const chunk = lookups.slice(i, i + NAME_POINTER_LOOKUP_CONCURRENCY)
+      const profiles = await Promise.all(chunk.map((pointer) => getProfileByNamePointer(pointer)))
+
+      chunk.forEach((pointer, index) => {
+        const profile = profiles[index]
+        if (profile) {
+          matched.set(pointer.toLowerCase(), profile)
+        }
+      })
+    }
+
+    return matched
+  }
+
   async function getProfiles(pointers: string[]): Promise<Map<string, Profile>> {
     const profilesByPointer = new Map<string, Profile>()
 
@@ -246,28 +277,33 @@ export async function createCatalystAdapter({
     // default profile shares the same one, so they can only be correlated one request at a time
     const addressPointers: string[] = []
     const namePointers: string[] = []
+    let ignored = 0
 
     for (const pointer of pointers) {
-      if (EthAddress.validate(pointer)) {
+      // Validated on the normalized form, since every layer keys by the lowercased pointer
+      const isAddress: boolean = EthAddress.validate(pointer.toLowerCase())
+
+      if (isAddress) {
         addressPointers.push(pointer)
-      } else {
+      } else if (pointer.toLowerCase().startsWith(DEFAULT_PROFILE_POINTER_PREFIX)) {
         namePointers.push(pointer)
+      } else {
+        // Neither an address nor a default profile name, so it cannot match any profile
+        ignored++
       }
+    }
+
+    if (ignored > 0) {
+      logger.debug('Ignored pointers that are neither an address nor a default profile name', { ignored })
     }
 
     const [byAddress, byName] = await Promise.all([
       getProfilesByAddress(addressPointers),
-      Promise.all(namePointers.map(async (pointer) => [pointer, await getProfileByNamePointer(pointer)] as const))
+      getProfilesByNamePointers(namePointers)
     ])
 
-    for (const [pointer, profile] of byAddress) {
+    for (const [pointer, profile] of [...byAddress, ...byName]) {
       profilesByPointer.set(pointer, profile)
-    }
-
-    for (const [pointer, profile] of byName) {
-      if (profile) {
-        profilesByPointer.set(pointer.toLowerCase(), profile)
-      }
     }
 
     return profilesByPointer

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -176,37 +176,14 @@ export async function createCatalystAdapter({
     try {
       const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: pointers })
 
-      // The response has no requested-id echo, so profiles are matched on the address in their
-      // metadata: only requested pointers are accepted, and a repeated one is dropped as ambiguous
-      const requested = new Set(pointers.map((pointer) => pointer.toLowerCase()))
-      const ambiguous = new Set<string>()
-
+      // Lambdas serves the identity of an address profile from the entity pointer, so the address in
+      // the response is what the profile was requested for
       for (const profile of profiles) {
-        const metadataAddress = profile.avatars?.[0]?.ethAddress?.toLowerCase()
+        const address = profile.avatars?.[0]?.ethAddress?.toLowerCase()
 
-        if (!metadataAddress || !requested.has(metadataAddress)) {
-          continue
+        if (address) {
+          matched.set(address, profile)
         }
-
-        if (matched.has(metadataAddress)) {
-          ambiguous.add(metadataAddress)
-          continue
-        }
-
-        matched.set(metadataAddress, profile)
-      }
-
-      for (const pointer of ambiguous) {
-        matched.delete(pointer)
-        logger.warn('Discarded profiles sharing the same address', { pointer })
-      }
-
-      if (matched.size !== profiles.length) {
-        logger.warn('Discarded profiles not matching any requested pointer', {
-          requested: pointers.length,
-          received: profiles.length,
-          matched: matched.size
-        })
       }
     } catch (error: any) {
       logger.error('Error fetching profiles from historical catalyst lambdas', {

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -37,21 +37,21 @@ export async function createCatalystAdapter({
     return match ? match[1] : null
   }
 
-  function convertLambdasProfileToEntity(profile: Profile): Entity | null {
+  function convertLambdasProfileToEntity(profile: Profile, pointer: string): Entity | null {
     const avatar = profile.avatars?.[0]
-    if (!avatar?.ethAddress) {
+    if (!avatar) {
       return null
     }
 
     const snapshotUrl = avatar.avatar?.snapshots?.body || avatar.avatar?.snapshots?.face256
     if (!snapshotUrl) {
-      logger.warn('Profile has no snapshot URL to extract entity ID', { pointer: avatar.ethAddress })
+      logger.warn('Profile has no snapshot URL to extract entity ID', { pointer })
       return null
     }
 
     const entityId = extractEntityIdFromSnapshotUrl(snapshotUrl)
     if (!entityId) {
-      logger.warn('Could not extract entity ID from snapshot URL', { snapshotUrl, pointer: avatar.ethAddress })
+      logger.warn('Could not extract entity ID from snapshot URL', { snapshotUrl, pointer })
       return null
     }
 
@@ -59,7 +59,8 @@ export async function createCatalystAdapter({
       version: 'v3',
       id: entityId,
       type: EntityType.PROFILE,
-      pointers: [avatar.ethAddress.toLowerCase()],
+      // Supplied by the caller so the entity is keyed by the pointer it was requested for
+      pointers: [pointer.toLowerCase()],
       timestamp: profile.timestamp!,
       content: [],
       metadata: { avatars: profile.avatars }
@@ -163,23 +164,56 @@ export async function createCatalystAdapter({
     return contentJson as Entity
   }
 
-  async function getProfiles(pointers: string[]): Promise<Profile[]> {
+  async function getProfiles(pointers: string[]): Promise<Map<string, Profile>> {
+    const profilesByPointer = new Map<string, Profile>()
+
     if (pointers.length === 0) {
-      return []
+      return profilesByPointer
     }
 
     try {
       const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: pointers })
-      const profilesWithAvatars = profiles.filter(
-        (profile) => profile.avatars && profile.avatars.length > 0 && profile.avatars[0].ethAddress
-      )
-      return profilesWithAvatars
+
+      // The response has no requested-id echo, so profiles are matched on the address in their
+      // metadata: only requested pointers are accepted, and a repeated one is dropped as ambiguous
+      const requested = new Set(pointers.map((pointer) => pointer.toLowerCase()))
+      const ambiguous = new Set<string>()
+
+      for (const profile of profiles) {
+        const metadataAddress = profile.avatars?.[0]?.ethAddress?.toLowerCase()
+
+        if (!metadataAddress || !requested.has(metadataAddress)) {
+          continue
+        }
+
+        if (profilesByPointer.has(metadataAddress)) {
+          ambiguous.add(metadataAddress)
+          continue
+        }
+
+        profilesByPointer.set(metadataAddress, profile)
+      }
+
+      for (const pointer of ambiguous) {
+        profilesByPointer.delete(pointer)
+        logger.warn('Discarded profiles sharing the same address', { pointer })
+      }
+
+      if (profilesByPointer.size !== profiles.length) {
+        logger.warn('Discarded profiles not matching any requested pointer', {
+          requested: pointers.length,
+          received: profiles.length,
+          matched: profilesByPointer.size
+        })
+      }
+
+      return profilesByPointer
     } catch (error: any) {
       logger.error('Error fetching profiles from historical catalyst lambdas', {
         error: error?.message || 'Unknown error',
         count: pointers.length
       })
-      return []
+      return new Map()
     }
   }
 

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityType } from '@dcl/schemas'
+import { Entity, EntityType, EthAddress } from '@dcl/schemas'
 import { IFetchComponent, RequestOptions } from '@dcl/core-commons'
 import { ContentClient, createContentClient, createLambdasClient } from 'dcl-catalyst-client'
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
@@ -164,11 +164,11 @@ export async function createCatalystAdapter({
     return contentJson as Entity
   }
 
-  async function getProfiles(pointers: string[]): Promise<Map<string, Profile>> {
-    const profilesByPointer = new Map<string, Profile>()
+  async function getProfilesByAddress(pointers: string[]): Promise<Map<string, Profile>> {
+    const matched = new Map<string, Profile>()
 
     if (pointers.length === 0) {
-      return profilesByPointer
+      return matched
     }
 
     try {
@@ -186,35 +186,91 @@ export async function createCatalystAdapter({
           continue
         }
 
-        if (profilesByPointer.has(metadataAddress)) {
+        if (matched.has(metadataAddress)) {
           ambiguous.add(metadataAddress)
           continue
         }
 
-        profilesByPointer.set(metadataAddress, profile)
+        matched.set(metadataAddress, profile)
       }
 
       for (const pointer of ambiguous) {
-        profilesByPointer.delete(pointer)
+        matched.delete(pointer)
         logger.warn('Discarded profiles sharing the same address', { pointer })
       }
 
-      if (profilesByPointer.size !== profiles.length) {
+      if (matched.size !== profiles.length) {
         logger.warn('Discarded profiles not matching any requested pointer', {
           requested: pointers.length,
           received: profiles.length,
-          matched: profilesByPointer.size
+          matched: matched.size
         })
       }
-
-      return profilesByPointer
     } catch (error: any) {
       logger.error('Error fetching profiles from historical catalyst lambdas', {
         error: error?.message || 'Unknown error',
         count: pointers.length
       })
-      return new Map()
     }
+
+    return matched
+  }
+
+  async function getProfileByNamePointer(pointer: string): Promise<Profile | null> {
+    try {
+      const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: [pointer] })
+
+      // Asked for one pointer, so anything other than a single profile cannot be correlated
+      if (profiles.length !== 1 || !profiles[0].avatars?.[0]) {
+        return null
+      }
+
+      return profiles[0]
+    } catch (error: any) {
+      logger.error('Error fetching profile from historical catalyst lambdas', {
+        pointer,
+        error: error?.message || 'Unknown error'
+      })
+      return null
+    }
+  }
+
+  async function getProfiles(pointers: string[]): Promise<Map<string, Profile>> {
+    const profilesByPointer = new Map<string, Profile>()
+
+    if (pointers.length === 0) {
+      return profilesByPointer
+    }
+
+    // Name pointers (default profiles) carry an unrelated address in their metadata, and every
+    // default profile shares the same one, so they can only be correlated one request at a time
+    const addressPointers: string[] = []
+    const namePointers: string[] = []
+
+    for (const pointer of pointers) {
+      if (EthAddress.validate(pointer)) {
+        addressPointers.push(pointer)
+      } else {
+        namePointers.push(pointer)
+      }
+    }
+
+    const [byAddress, byName] = await Promise.all([
+      getProfilesByAddress(addressPointers),
+      Promise.all(namePointers.map(async (pointer) => [pointer, await getProfileByNamePointer(pointer)] as const))
+    ])
+
+    for (const [pointer, profile] of byAddress) {
+      profilesByPointer.set(pointer, profile)
+    }
+
+    for (const [pointer, profile] of byName) {
+      if (profile) {
+        profilesByPointer.set(pointer.toLowerCase(), profile)
+      }
+    }
+
+    return profilesByPointer
   }
 
   return {

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -4,7 +4,7 @@ import { ContentClient, createContentClient, createLambdasClient } from 'dcl-cat
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 
 import { AppComponents, ICatalystComponent, CatalystFetchOptions } from '../types'
-import { isAddressPointer } from '../utils/pointers'
+import { isAddressPointer, isDefaultProfilePointer } from '../utils/pointers'
 
 const ENTITY_ID_FROM_SNAPSHOT_REGEX = /\/entities\/([^/]+)\//
 
@@ -173,10 +173,13 @@ export async function createCatalystAdapter({
     // cannot be attributed to the name it was asked for. Only address pointers are looked up here;
     // names resolve from the cache or the database, where this service syncs those deployments.
     const addressPointers = pointers.filter(isAddressPointer)
+    const skipped = pointers.filter((pointer) => !isAddressPointer(pointer))
+    const defaultProfiles = skipped.filter(isDefaultProfilePointer).length
 
-    if (addressPointers.length !== pointers.length) {
+    if (skipped.length > 0) {
       logger.debug('Skipping catalyst lookup for pointers that are not addresses', {
-        skipped: pointers.length - addressPointers.length
+        defaultProfiles,
+        notAPointer: skipped.length - defaultProfiles
       })
     }
 

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -39,12 +39,14 @@ export async function createCatalystAdapter({
   }
 
   function convertLambdasProfileToEntity(profile: Profile): Entity | null {
-    const avatar = profile.avatars?.[0]
+    const avatars = profile.avatars ?? []
+    const avatar = avatars[0]
+
     if (!avatar?.ethAddress) {
       return null
     }
 
-    const pointer = avatar.ethAddress
+    const pointer = avatar.ethAddress.toLowerCase()
 
     const snapshotUrl = avatar.avatar?.snapshots?.body || avatar.avatar?.snapshots?.face256
     if (!snapshotUrl) {
@@ -62,10 +64,18 @@ export async function createCatalystAdapter({
       version: 'v3',
       id: entityId,
       type: EntityType.PROFILE,
-      pointers: [pointer.toLowerCase()],
+      pointers: [pointer],
       timestamp: profile.timestamp!,
       content: [],
-      metadata: { avatars: profile.avatars }
+      // The entity is keyed by this pointer, so the identity it carries is settled to match it: the
+      // node this came from serves it from the pointer, but only from the version that does so
+      metadata: {
+        avatars: avatars.map((profileAvatar) => ({
+          ...profileAvatar,
+          userId: pointer,
+          ethAddress: pointer
+        }))
+      }
     }
   }
 

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -4,6 +4,7 @@ import { ContentClient, createContentClient, createLambdasClient } from 'dcl-cat
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 
 import { AppComponents, ICatalystComponent, CatalystFetchOptions } from '../types'
+import { isAddressPointer } from '../utils/pointers'
 
 const ENTITY_ID_FROM_SNAPSHOT_REGEX = /\/entities\/([^/]+)\//
 
@@ -168,12 +169,23 @@ export async function createCatalystAdapter({
   async function getProfiles(pointers: string[]): Promise<Map<string, Profile>> {
     const profilesByPointer = new Map<string, Profile>()
 
-    if (pointers.length === 0) {
+    // A default profile is pointed at by name and reports the deployer's address, so its response
+    // cannot be attributed to the name it was asked for. Only address pointers are looked up here;
+    // names resolve from the cache or the database, where this service syncs those deployments.
+    const addressPointers = pointers.filter(isAddressPointer)
+
+    if (addressPointers.length !== pointers.length) {
+      logger.debug('Skipping catalyst lookup for pointers that are not addresses', {
+        skipped: pointers.length - addressPointers.length
+      })
+    }
+
+    if (addressPointers.length === 0) {
       return profilesByPointer
     }
 
     try {
-      const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: pointers })
+      const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: addressPointers })
 
       // Lambdas serves an address profile's identity from the entity pointer, so the address it
       // reports is the pointer the profile was requested for
@@ -187,7 +199,7 @@ export async function createCatalystAdapter({
     } catch (error: any) {
       logger.error('Error fetching profiles from historical catalyst lambdas', {
         error: error?.message || 'Unknown error',
-        count: pointers.length
+        count: addressPointers.length
       })
     }
 

--- a/src/controllers/handlers/get-profiles-metadata.ts
+++ b/src/controllers/handlers/get-profiles-metadata.ts
@@ -1,4 +1,5 @@
 import { HandlerContextWithPath } from '../../types'
+import { parseProfilePointers } from '../schemas/profiles'
 
 export async function getProfilesMetadataHandler(
   context: HandlerContextWithPath<'profileRetriever' | 'profileSanitizer', '/profiles/metadata'>
@@ -8,7 +9,7 @@ export async function getProfilesMetadataHandler(
   } = context
 
   const body = await context.request.json()
-  const pointers: string[] = body.ids
+  const pointers = parseProfilePointers(body)
 
   const profilesMap = await profileRetriever.getProfiles(pointers)
 

--- a/src/controllers/handlers/get-profiles.ts
+++ b/src/controllers/handlers/get-profiles.ts
@@ -1,4 +1,5 @@
 import { HandlerContextWithPath } from '../../types'
+import { parseProfilePointers } from '../schemas/profiles'
 
 export async function getProfilesHandler(
   context: HandlerContextWithPath<'metrics' | 'profileRetriever' | 'profileSanitizer', '/profiles'>
@@ -8,7 +9,7 @@ export async function getProfilesHandler(
   } = context
 
   const body = await context.request.json()
-  const pointers: string[] = body.ids
+  const pointers = parseProfilePointers(body)
 
   metrics.observe('profiles_pointers_per_request', {}, pointers.length)
   const profilesMap = await profileRetriever.getProfiles(pointers)

--- a/src/controllers/schemas/profiles.ts
+++ b/src/controllers/schemas/profiles.ts
@@ -1,10 +1,10 @@
 import { InvalidRequestError } from '@dcl/http-commons'
 
-export const MAX_PROFILE_POINTERS_PER_REQUEST = 500
-
 /**
- * Validates the body of the profile endpoints, which fan out into cache, database and catalyst
- * lookups, so the amount of work a single request can ask for has to be bounded.
+ * Validates the shape of the body of the profile endpoints, so a malformed one is reported as a bad
+ * request instead of failing further down. The amount of ids is deliberately not capped: callers
+ * batch whole pages of friends or community members, and the lookups behind this are one upstream
+ * request regardless of how many are asked for.
  */
 function getIds(body: unknown): unknown {
   if (typeof body !== 'object' || body === null || !('ids' in body)) {
@@ -23,12 +23,6 @@ export function parseProfilePointers(body: unknown): string[] {
 
   if (!isNonEmptyStringArray(pointers)) {
     throw new InvalidRequestError('The ids property must be an array of non-empty strings')
-  }
-
-  if (pointers.length > MAX_PROFILE_POINTERS_PER_REQUEST) {
-    throw new InvalidRequestError(
-      `A maximum of ${MAX_PROFILE_POINTERS_PER_REQUEST} ids can be requested at once, got ${pointers.length}`
-    )
   }
 
   return pointers

--- a/src/controllers/schemas/profiles.ts
+++ b/src/controllers/schemas/profiles.ts
@@ -1,13 +1,10 @@
 import { InvalidRequestError } from '@dcl/http-commons'
-import { isDefaultProfilePointer } from '../../utils/pointers'
 
 export const MAX_PROFILE_POINTERS_PER_REQUEST = 500
-export const MAX_NAME_POINTERS_PER_REQUEST = 25
 
 /**
  * Validates the body of the profile endpoints, which fan out into cache, database and catalyst
- * lookups, so the amount of work a single request can ask for has to be bounded. Name pointers get
- * a lower limit because they cannot be batched: each one costs its own catalyst request.
+ * lookups, so the amount of work a single request can ask for has to be bounded.
  */
 function getIds(body: unknown): unknown {
   if (typeof body !== 'object' || body === null || !('ids' in body)) {
@@ -31,14 +28,6 @@ export function parseProfilePointers(body: unknown): string[] {
   if (pointers.length > MAX_PROFILE_POINTERS_PER_REQUEST) {
     throw new InvalidRequestError(
       `A maximum of ${MAX_PROFILE_POINTERS_PER_REQUEST} ids can be requested at once, got ${pointers.length}`
-    )
-  }
-
-  const namePointers = pointers.filter(isDefaultProfilePointer)
-
-  if (namePointers.length > MAX_NAME_POINTERS_PER_REQUEST) {
-    throw new InvalidRequestError(
-      `A maximum of ${MAX_NAME_POINTERS_PER_REQUEST} default profile ids can be requested at once, got ${namePointers.length}`
     )
   }
 

--- a/src/controllers/schemas/profiles.ts
+++ b/src/controllers/schemas/profiles.ts
@@ -1,0 +1,23 @@
+import { InvalidRequestError } from '@dcl/http-commons'
+
+export const MAX_PROFILE_POINTERS_PER_REQUEST = 500
+
+/**
+ * Validates the body of the profile endpoints, which fan out into cache, database and catalyst
+ * lookups, so the amount of work a single request can ask for has to be bounded.
+ */
+export function parseProfilePointers(body: any): string[] {
+  const pointers = body?.ids
+
+  if (!Array.isArray(pointers) || pointers.some((pointer) => typeof pointer !== 'string' || pointer.length === 0)) {
+    throw new InvalidRequestError('The ids property must be an array of non-empty strings')
+  }
+
+  if (pointers.length > MAX_PROFILE_POINTERS_PER_REQUEST) {
+    throw new InvalidRequestError(
+      `A maximum of ${MAX_PROFILE_POINTERS_PER_REQUEST} ids can be requested at once, got ${pointers.length}`
+    )
+  }
+
+  return pointers
+}

--- a/src/controllers/schemas/profiles.ts
+++ b/src/controllers/schemas/profiles.ts
@@ -9,8 +9,16 @@ export const MAX_NAME_POINTERS_PER_REQUEST = 25
  * lookups, so the amount of work a single request can ask for has to be bounded. Name pointers get
  * a lower limit because they cannot be batched: each one costs its own catalyst request.
  */
-export function parseProfilePointers(body: any): string[] {
-  const pointers = body?.ids
+function getIds(body: unknown): unknown {
+  if (typeof body !== 'object' || body === null || !('ids' in body)) {
+    return undefined
+  }
+
+  return body.ids
+}
+
+export function parseProfilePointers(body: unknown): string[] {
+  const pointers = getIds(body)
 
   if (!Array.isArray(pointers) || pointers.some((pointer) => typeof pointer !== 'string' || pointer.length === 0)) {
     throw new InvalidRequestError('The ids property must be an array of non-empty strings')
@@ -22,9 +30,7 @@ export function parseProfilePointers(body: any): string[] {
     )
   }
 
-  const namePointers = pointers.filter(
-    (pointer: string) => !isAddressPointer(pointer) && isDefaultProfilePointer(pointer)
-  )
+  const namePointers = pointers.filter((pointer) => !isAddressPointer(pointer) && isDefaultProfilePointer(pointer))
 
   if (namePointers.length > MAX_NAME_POINTERS_PER_REQUEST) {
     throw new InvalidRequestError(

--- a/src/controllers/schemas/profiles.ts
+++ b/src/controllers/schemas/profiles.ts
@@ -1,5 +1,5 @@
 import { InvalidRequestError } from '@dcl/http-commons'
-import { isAddressPointer, isDefaultProfilePointer } from '../../utils/pointers'
+import { isDefaultProfilePointer } from '../../utils/pointers'
 
 export const MAX_PROFILE_POINTERS_PER_REQUEST = 500
 export const MAX_NAME_POINTERS_PER_REQUEST = 25
@@ -17,10 +17,14 @@ function getIds(body: unknown): unknown {
   return body.ids
 }
 
+function isNonEmptyStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((pointer) => typeof pointer === 'string' && pointer.length > 0)
+}
+
 export function parseProfilePointers(body: unknown): string[] {
   const pointers = getIds(body)
 
-  if (!Array.isArray(pointers) || pointers.some((pointer) => typeof pointer !== 'string' || pointer.length === 0)) {
+  if (!isNonEmptyStringArray(pointers)) {
     throw new InvalidRequestError('The ids property must be an array of non-empty strings')
   }
 
@@ -30,7 +34,7 @@ export function parseProfilePointers(body: unknown): string[] {
     )
   }
 
-  const namePointers = pointers.filter((pointer) => !isAddressPointer(pointer) && isDefaultProfilePointer(pointer))
+  const namePointers = pointers.filter(isDefaultProfilePointer)
 
   if (namePointers.length > MAX_NAME_POINTERS_PER_REQUEST) {
     throw new InvalidRequestError(

--- a/src/controllers/schemas/profiles.ts
+++ b/src/controllers/schemas/profiles.ts
@@ -1,10 +1,13 @@
 import { InvalidRequestError } from '@dcl/http-commons'
+import { isAddressPointer, isDefaultProfilePointer } from '../../utils/pointers'
 
 export const MAX_PROFILE_POINTERS_PER_REQUEST = 500
+export const MAX_NAME_POINTERS_PER_REQUEST = 25
 
 /**
  * Validates the body of the profile endpoints, which fan out into cache, database and catalyst
- * lookups, so the amount of work a single request can ask for has to be bounded.
+ * lookups, so the amount of work a single request can ask for has to be bounded. Name pointers get
+ * a lower limit because they cannot be batched: each one costs its own catalyst request.
  */
 export function parseProfilePointers(body: any): string[] {
   const pointers = body?.ids
@@ -16,6 +19,16 @@ export function parseProfilePointers(body: any): string[] {
   if (pointers.length > MAX_PROFILE_POINTERS_PER_REQUEST) {
     throw new InvalidRequestError(
       `A maximum of ${MAX_PROFILE_POINTERS_PER_REQUEST} ids can be requested at once, got ${pointers.length}`
+    )
+  }
+
+  const namePointers = pointers.filter(
+    (pointer: string) => !isAddressPointer(pointer) && isDefaultProfilePointer(pointer)
+  )
+
+  if (namePointers.length > MAX_NAME_POINTERS_PER_REQUEST) {
+    throw new InvalidRequestError(
+      `A maximum of ${MAX_NAME_POINTERS_PER_REQUEST} default profile ids can be requested at once, got ${namePointers.length}`
     )
   }
 

--- a/src/logic/profile-retriever.ts
+++ b/src/logic/profile-retriever.ts
@@ -73,7 +73,8 @@ export function createProfileRetrieverComponent(
   }
 
   async function getProfiles(pointers: string[]): Promise<Map<string, Entity>> {
-    const uniquePointers = [...new Set(pointers)]
+    // Every layer below keys by the lowercased pointer, so case variants are the same request
+    const uniquePointers = [...new Set(pointers.map((pointer) => pointer.toLowerCase()))]
     let retrievedProfiles = new Map<string, Entity>()
 
     // Layer 1: Batch fetch from hot cache (L1 cache)

--- a/src/logic/profile-retriever.ts
+++ b/src/logic/profile-retriever.ts
@@ -109,7 +109,13 @@ export function createProfileRetrieverComponent(
 
     // Layer 3: Fall-back to Catalyst
     logger.debug('Fetching remaining profiles from Catalyst', { count: pointersMissingFromDB.length })
-    const profilesFromCatalyst = await getFromCatalyst(pointersMissingFromDB)
+    const requested = new Set(uniquePointers)
+    // Scoped before anything is written: a profile for a pointer this request did not ask for has no
+    // business warming the cache or the database as a side effect of it
+    const profilesFromCatalyst = (await getFromCatalyst(pointersMissingFromDB)).filter((profile) =>
+      requested.has(profile.pointers[0].toLowerCase())
+    )
+
     if (profilesFromCatalyst.length > 0) {
       await Promise.all(profilesFromCatalyst.map((p) => entityPersister.persistEntity(p)))
       for (const profile of profilesFromCatalyst) retrievedProfiles.set(profile.pointers[0].toLowerCase(), profile)
@@ -118,7 +124,6 @@ export function createProfileRetrieverComponent(
     metrics.increment('profiles_retrieved_from_catalyst', {}, profilesFromCatalyst.length)
 
     // Only what was asked for belongs in the result, whichever layer answered
-    const requested = new Set(uniquePointers)
     const unrequested = Array.from(retrievedProfiles.keys()).filter((pointer) => !requested.has(pointer))
 
     for (const pointer of unrequested) {

--- a/src/logic/profile-retriever.ts
+++ b/src/logic/profile-retriever.ts
@@ -55,11 +55,11 @@ export function createProfileRetrieverComponent(
 
   async function getFromCatalyst(pointers: string[]): Promise<Entity[]> {
     try {
-      const profiles = await catalyst.getProfiles(pointers)
+      const profilesByPointer = await catalyst.getProfiles(pointers)
       const entities: Entity[] = []
 
-      for (const profile of profiles) {
-        const entity = catalyst.convertLambdasProfileToEntity(profile)
+      for (const [pointer, profile] of profilesByPointer) {
+        const entity = catalyst.convertLambdasProfileToEntity(profile, pointer)
         if (entity) {
           entities.push(entity)
         }
@@ -100,7 +100,7 @@ export function createProfileRetrieverComponent(
     metrics.increment('profiles_retrieved_from_database', {}, profilesFromDB.length)
 
     const pointersFoundInDB = new Set(profilesFromDB.map((p) => p.pointers[0].toLowerCase()))
-    const pointersMissingFromDB = cacheMisses.filter((p) => !pointersFoundInDB.has(p))
+    const pointersMissingFromDB = cacheMisses.filter((p) => !pointersFoundInDB.has(p.toLowerCase()))
     if (pointersMissingFromDB.length === 0) {
       logger.debug('All remaining profiles found in database', { total: retrievedProfiles.size })
       return retrievedProfiles

--- a/src/logic/profile-retriever.ts
+++ b/src/logic/profile-retriever.ts
@@ -58,8 +58,8 @@ export function createProfileRetrieverComponent(
       const profilesByPointer = await catalyst.getProfiles(pointers)
       const entities: Entity[] = []
 
-      for (const [pointer, profile] of profilesByPointer) {
-        const entity = catalyst.convertLambdasProfileToEntity(profile, pointer)
+      for (const profile of profilesByPointer.values()) {
+        const entity = catalyst.convertLambdasProfileToEntity(profile)
         if (entity) {
           entities.push(entity)
         }

--- a/src/logic/profile-retriever.ts
+++ b/src/logic/profile-retriever.ts
@@ -117,6 +117,18 @@ export function createProfileRetrieverComponent(
     }
     metrics.increment('profiles_retrieved_from_catalyst', {}, profilesFromCatalyst.length)
 
+    // Only what was asked for belongs in the result, whichever layer answered
+    const requested = new Set(uniquePointers)
+    const unrequested = Array.from(retrievedProfiles.keys()).filter((pointer) => !requested.has(pointer))
+
+    for (const pointer of unrequested) {
+      retrievedProfiles.delete(pointer)
+    }
+
+    if (unrequested.length > 0) {
+      logger.debug('Left out profiles that were not requested', { count: unrequested.length })
+    }
+
     const notFoundPointers: Set<string> = new Set(uniquePointers.filter((p) => !retrievedProfiles.has(p.toLowerCase())))
     metrics.increment('profiles_not_found', {}, notFoundPointers.size)
 

--- a/src/logic/sync/ownership-validator-job.ts
+++ b/src/logic/sync/ownership-validator-job.ts
@@ -72,19 +72,12 @@ export async function createOwnershipValidatorJob(
       return 0
     }
 
-    const fetchedProfiles = await catalyst.getProfiles(pointers)
+    // Keyed by the requested pointer rather than by the identity metadata
+    const sanitizedMap = await catalyst.getProfiles(pointers)
 
-    if (fetchedProfiles.length === 0) {
+    if (sanitizedMap.size === 0) {
       logger.warn('No profiles returned from lamb2', { requestedCount: pointers.length })
       return 0
-    }
-
-    // Build sanitized map keyed by lowercased userId
-    const sanitizedMap = new Map<string, Profile>()
-    for (const profile of fetchedProfiles) {
-      if (profile.avatars?.[0]?.userId) {
-        sanitizedMap.set(profile.avatars[0].userId.toLowerCase(), profile)
-      }
     }
 
     const cachedMap = profilesCache.getMany(pointers)
@@ -104,12 +97,17 @@ export async function createOwnershipValidatorJob(
       }
 
       const originalProfile = originalProfileMap.get(pointer)
-      const sanitizedProfile = sanitizedMap.get(pointer)
+      const sanitizedProfile = sanitizedMap.get(pointer.toLowerCase())
 
-      if (originalProfile && sanitizedProfile && shouldUpdateProfile(originalProfile, sanitizedProfile)) {
+      if (!sanitizedProfile) {
+        logger.warn('Skipping validation, no matching profile returned', { pointer })
+        continue
+      }
+
+      if (originalProfile && shouldUpdateProfile(originalProfile, sanitizedProfile)) {
         logger.info('Profile update required', { pointer })
 
-        const curatedProfile = catalyst.convertLambdasProfileToEntity(sanitizedProfile)
+        const curatedProfile = catalyst.convertLambdasProfileToEntity(sanitizedProfile, pointer)
 
         if (!curatedProfile) {
           logger.error('Failed to convert sanitized profile to entity', { pointer })

--- a/src/logic/sync/ownership-validator-job.ts
+++ b/src/logic/sync/ownership-validator-job.ts
@@ -107,7 +107,7 @@ export async function createOwnershipValidatorJob(
       if (originalProfile && shouldUpdateProfile(originalProfile, sanitizedProfile)) {
         logger.info('Profile update required', { pointer })
 
-        const curatedProfile = catalyst.convertLambdasProfileToEntity(sanitizedProfile, pointer)
+        const curatedProfile = catalyst.convertLambdasProfileToEntity(sanitizedProfile)
 
         if (!curatedProfile) {
           logger.error('Failed to convert sanitized profile to entity', { pointer })

--- a/src/logic/sync/ownership-validator-job.ts
+++ b/src/logic/sync/ownership-validator-job.ts
@@ -4,6 +4,7 @@ import { AvatarInfo, Entity, EntityType } from '@dcl/schemas'
 import { Sync } from '../../types'
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 import { interruptibleSleep } from '../../utils/timer'
+import { isAddressPointer } from '../../utils/pointers'
 
 // Timing constants
 const TEN_MINUTES_MS = 10 * 60 * 1000
@@ -94,6 +95,12 @@ export async function createOwnershipValidatorJob(
     for (const pointer of pointers) {
       if (abortSignal.aborted) {
         break
+      }
+
+      // A default profile is pointed at by name, which a catalyst response cannot be attributed to,
+      // so there is nothing to validate it against
+      if (!isAddressPointer(pointer)) {
+        continue
       }
 
       const originalProfile = originalProfileMap.get(pointer)

--- a/src/logic/sync/profile-sanitizer.ts
+++ b/src/logic/sync/profile-sanitizer.ts
@@ -56,6 +56,9 @@ export async function createProfileSanitizerComponent({
     return profiles.map((profile) => {
       const snapshots = buildProfilesSnapshots(profile.id)
       const metadata = profile.metadata as Profile
+      const pointer = profile.pointers[0]
+      // The pointer is the authoritative identity, not the deployed metadata
+      const identity = pointer.startsWith('default') ? {} : { userId: pointer, ethAddress: pointer }
 
       return {
         ...profile,
@@ -65,6 +68,7 @@ export async function createProfileSanitizerComponent({
             if (avatar.avatar) {
               return {
                 ...avatar,
+                ...identity,
                 avatar: {
                   ...avatar.avatar,
                   snapshots: {
@@ -74,7 +78,7 @@ export async function createProfileSanitizerComponent({
                 }
               }
             }
-            return avatar
+            return { ...avatar, ...identity }
           })
         }
       }

--- a/src/logic/sync/profile-sanitizer.ts
+++ b/src/logic/sync/profile-sanitizer.ts
@@ -31,7 +31,42 @@ export async function createProfileSanitizerComponent({
       await notFoundProfilesHandler(missingProfile)
     }
 
-    return profilesFetched as Entity[]
+    const expectedPointers = new Map(minimalProfiles.map((p) => [p.entityId, p.pointer.toLowerCase()]))
+
+    return (profilesFetched as Entity[]).filter((profile) => validateFetchedProfile(profile, expectedPointers))
+  }
+
+  /**
+   * The entity is stored and served as fetched, so what it carries is checked once here rather than
+   * trusted on every read.
+   */
+  function validateFetchedProfile(profile: Entity, expectedPointers: Map<string, string>): boolean {
+    const pointer = profile.pointers?.[0]
+
+    if (!pointer) {
+      logger.warn('Discarding fetched profile without a pointer', { entityId: profile.id })
+      return false
+    }
+
+    const expectedPointer = expectedPointers.get(profile.id)
+
+    if (expectedPointer && pointer.toLowerCase() !== expectedPointer) {
+      logger.warn('Discarding fetched profile pointing somewhere else than its deployment', {
+        entityId: profile.id,
+        pointer,
+        expectedPointer
+      })
+      return false
+    }
+
+    const avatars = (profile.metadata as Profile | undefined)?.avatars
+
+    if (!Array.isArray(avatars) || avatars.length === 0) {
+      logger.warn('Discarding fetched profile without avatars', { entityId: profile.id, pointer })
+      return false
+    }
+
+    return true
   }
 
   function buildProfilesSnapshots(entityId: string): { body: string; face: string } {

--- a/src/logic/sync/profile-sanitizer.ts
+++ b/src/logic/sync/profile-sanitizer.ts
@@ -1,4 +1,4 @@
-import { Entity, Profile } from '@dcl/schemas'
+import { Entity, EthAddress, Profile } from '@dcl/schemas'
 import { AppComponents, IProfileSanitizerComponent, Sync, ProfileMetadataDTO, ProfileDTO } from '../../types'
 import { withRetry, withTimeout } from '../../utils/timer'
 
@@ -57,8 +57,8 @@ export async function createProfileSanitizerComponent({
       const snapshots = buildProfilesSnapshots(profile.id)
       const metadata = profile.metadata as Profile
       const pointer = profile.pointers[0]
-      // The pointer is the authoritative identity, not the deployed metadata
-      const identity = pointer.startsWith('default') ? {} : { userId: pointer, ethAddress: pointer }
+      // Authoritative identity for address pointers; default profiles are pointed at by name
+      const identity = EthAddress.validate(pointer) ? { userId: pointer, ethAddress: pointer } : {}
 
       return {
         ...profile,

--- a/src/logic/sync/profile-sanitizer.ts
+++ b/src/logic/sync/profile-sanitizer.ts
@@ -1,6 +1,7 @@
-import { Entity, EthAddress, Profile } from '@dcl/schemas'
+import { Entity, Profile } from '@dcl/schemas'
 import { AppComponents, IProfileSanitizerComponent, Sync, ProfileMetadataDTO, ProfileDTO } from '../../types'
 import { withRetry, withTimeout } from '../../utils/timer'
+import { isAddressPointer } from '../../utils/pointers'
 
 const THIRTY_SECONDS_IN_MS = 30000
 
@@ -33,7 +34,34 @@ export async function createProfileSanitizerComponent({
 
     const expectedPointers = new Map(minimalProfiles.map((p) => [p.entityId, p.pointer.toLowerCase()]))
 
-    return (profilesFetched as Entity[]).filter((profile) => validateFetchedProfile(profile, expectedPointers))
+    return (profilesFetched as Entity[])
+      .filter((profile) => validateFetchedProfile(profile, expectedPointers))
+      .map(withIdentityFromPointer)
+  }
+
+  /**
+   * Deployed metadata carries its own `userId` and `ethAddress`, which need not agree with the
+   * pointer for profiles deployed before the validator enforced it. The pointer is authoritative, so
+   * they are settled here, once, instead of on every read. Default profiles keep their deployed
+   * value, since their pointer is a name.
+   */
+  function withIdentityFromPointer(profile: Entity): Entity {
+    const pointer = profile.pointers[0]
+
+    if (!isAddressPointer(pointer)) {
+      return profile
+    }
+
+    const metadata = profile.metadata as Profile
+    const identity = { userId: pointer.toLowerCase(), ethAddress: pointer.toLowerCase() }
+
+    return {
+      ...profile,
+      metadata: {
+        ...metadata,
+        avatars: metadata.avatars.map((avatar) => ({ ...avatar, ...identity }))
+      }
+    }
   }
 
   /**
@@ -91,9 +119,6 @@ export async function createProfileSanitizerComponent({
     return profiles.map((profile) => {
       const snapshots = buildProfilesSnapshots(profile.id)
       const metadata = profile.metadata as Profile
-      const pointer = profile.pointers[0]
-      // Authoritative identity for address pointers; default profiles are pointed at by name
-      const identity = EthAddress.validate(pointer) ? { userId: pointer, ethAddress: pointer } : {}
 
       return {
         ...profile,
@@ -103,7 +128,6 @@ export async function createProfileSanitizerComponent({
             if (avatar.avatar) {
               return {
                 ...avatar,
-                ...identity,
                 avatar: {
                   ...avatar.avatar,
                   snapshots: {
@@ -113,7 +137,7 @@ export async function createProfileSanitizerComponent({
                 }
               }
             }
-            return { ...avatar, ...identity }
+            return avatar
           })
         }
       }

--- a/src/migrations/1769500000000_normalize-profile-identity.ts
+++ b/src/migrations/1769500000000_normalize-profile-identity.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+/**
+ * Settles the identity of already stored profiles from their pointer, which ingestion now does on the
+ * way in. Rows written before that keep whatever `userId` and `ethAddress` the deployer wrote, and
+ * those are what consumers read as the address of the profile.
+ *
+ * Only address pointers are touched: a default profile is pointed at by name and its metadata
+ * legitimately carries the deployer's address. Rows that already agree are left alone.
+ */
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    UPDATE profiles p
+    SET metadata = jsonb_set(
+          p.metadata,
+          '{avatars}',
+          (
+            SELECT jsonb_agg(
+                     avatar || jsonb_build_object('userId', lower(p.pointer), 'ethAddress', lower(p.pointer))
+                     ORDER BY position
+                   )
+            FROM jsonb_array_elements(p.metadata -> 'avatars') WITH ORDINALITY AS elements(avatar, position)
+          )
+        )
+    WHERE lower(p.pointer) ~ '^0x[0-9a-f]{40}$'
+      AND jsonb_typeof(p.metadata -> 'avatars') = 'array'
+      AND EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(p.metadata -> 'avatars') AS avatar
+        WHERE avatar ->> 'ethAddress' IS DISTINCT FROM lower(p.pointer)
+           OR avatar ->> 'userId' IS DISTINCT FROM lower(p.pointer)
+      )
+  `)
+}
+
+export async function down(): Promise<void> {
+  // The metadata this replaced is the deployed value, which is not recoverable from the row
+}

--- a/src/migrations/1769500000000_normalize-profile-identity.ts
+++ b/src/migrations/1769500000000_normalize-profile-identity.ts
@@ -3,36 +3,68 @@ import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
 
 export const shorthands: ColumnDefinitions | undefined = undefined
 
+const BATCH_SIZE = 1000
+
 /**
  * Settles the identity of already stored profiles from their pointer, which ingestion now does on the
  * way in. Rows written before that keep whatever `userId` and `ethAddress` the deployer wrote, and
  * those are what consumers read as the address of the profile.
  *
  * Only address pointers are touched: a default profile is pointed at by name and its metadata
- * legitimately carries the deployer's address. Rows that already agree are left alone.
+ * legitimately carries the deployer's address. Rows that already agree are skipped, which is what
+ * makes each batch shrink the remaining set and the loop terminate.
+ *
+ * Runs in batches outside a transaction: this table holds a row per profile on the network, so a
+ * single statement over all of it would hold locks for as long as it takes while the service waits
+ * to start.
  */
 export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction()
+
   pgm.sql(`
-    UPDATE profiles p
-    SET metadata = jsonb_set(
-          p.metadata,
-          '{avatars}',
-          (
-            SELECT jsonb_agg(
-                     avatar || jsonb_build_object('userId', lower(p.pointer), 'ethAddress', lower(p.pointer))
-                     ORDER BY position
-                   )
-            FROM jsonb_array_elements(p.metadata -> 'avatars') WITH ORDINALITY AS elements(avatar, position)
-          )
-        )
-    WHERE lower(p.pointer) ~ '^0x[0-9a-f]{40}$'
-      AND jsonb_typeof(p.metadata -> 'avatars') = 'array'
-      AND EXISTS (
-        SELECT 1
-        FROM jsonb_array_elements(p.metadata -> 'avatars') AS avatar
-        WHERE avatar ->> 'ethAddress' IS DISTINCT FROM lower(p.pointer)
-           OR avatar ->> 'userId' IS DISTINCT FROM lower(p.pointer)
-      )
+    DO $$
+    DECLARE
+      updated integer;
+    BEGIN
+      LOOP
+        UPDATE profiles p
+        SET metadata = jsonb_set(
+              p.metadata,
+              '{avatars}',
+              (
+                SELECT jsonb_agg(
+                         avatar || jsonb_build_object('userId', lower(p.pointer), 'ethAddress', lower(p.pointer))
+                         ORDER BY position
+                       )
+                FROM jsonb_array_elements(p.metadata -> 'avatars') WITH ORDINALITY AS elements(avatar, position)
+              )
+            )
+        WHERE p.id IN (
+          SELECT candidate.id
+          FROM profiles candidate
+          WHERE lower(candidate.pointer) ~ '^0x[0-9a-f]{40}$'
+            AND jsonb_typeof(candidate.metadata -> 'avatars') = 'array'
+            -- a non-object element cannot be merged with, so such a row is left as it is rather
+            -- than partially rewritten
+            AND NOT EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(candidate.metadata -> 'avatars') AS avatar
+              WHERE jsonb_typeof(avatar) <> 'object'
+            )
+            AND EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(candidate.metadata -> 'avatars') AS avatar
+              WHERE avatar ->> 'ethAddress' IS DISTINCT FROM lower(candidate.pointer)
+                 OR avatar ->> 'userId' IS DISTINCT FROM lower(candidate.pointer)
+            )
+          LIMIT ${BATCH_SIZE}
+        );
+
+        GET DIAGNOSTICS updated = ROW_COUNT;
+        EXIT WHEN updated = 0;
+        COMMIT;
+      END LOOP;
+    END $$;
   `)
 }
 

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -202,7 +202,7 @@ export interface ICatalystComponent {
   getEntityByPointers(pointers: string[]): Promise<Entity[]>
   getContent(id: string): Promise<Entity | undefined>
   getProfiles(pointers: string[]): Promise<Map<string, Profile>>
-  convertLambdasProfileToEntity(profile: Profile, pointer: string): Entity | null
+  convertLambdasProfileToEntity(profile: Profile): Entity | null
 }
 
 export interface IWorldsComponent {

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -201,8 +201,8 @@ export interface ICatalystComponent {
   getEntitiesByIds(ids: string[], options?: CatalystFetchOptions): Promise<Entity[]>
   getEntityByPointers(pointers: string[]): Promise<Entity[]>
   getContent(id: string): Promise<Entity | undefined>
-  getProfiles(pointers: string[]): Promise<Profile[]>
-  convertLambdasProfileToEntity(profile: Profile): Entity | null
+  getProfiles(pointers: string[]): Promise<Map<string, Profile>>
+  convertLambdasProfileToEntity(profile: Profile, pointer: string): Entity | null
 }
 
 export interface IWorldsComponent {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import { Color3, Entity, EntityType, EthAddress, Profile } from '@dcl/schemas'
+import { Color3, Entity, EntityType, Profile } from '@dcl/schemas'
 
 export namespace Sync {
   export type ProfileDbEntity = Omit<Entity, 'version' | 'pointers' | 'content'> & {
@@ -34,7 +34,7 @@ export namespace Sync {
 export type ProfileDTO = Profile & { timestamp: number }
 
 export type ProfileMetadataDTO = {
-  pointer: EthAddress
+  pointer: string
   hasClaimedName: boolean
   name: string
   nameColor?: Color3

--- a/src/utils/pointers.ts
+++ b/src/utils/pointers.ts
@@ -1,9 +1,15 @@
 import { EthAddress } from '@dcl/schemas'
 
+const DEFAULT_PROFILE_POINTER_REGEX = /^default\d+$/
+
 /**
  * Profile pointers are either an address or, for default profiles, a name. Matched on the lowercased
  * value, since every layer keys profiles by it.
  */
 export function isAddressPointer(pointer: string): boolean {
   return EthAddress.validate(pointer.toLowerCase())
+}
+
+export function isDefaultProfilePointer(pointer: string): boolean {
+  return DEFAULT_PROFILE_POINTER_REGEX.test(pointer.toLowerCase())
 }

--- a/src/utils/pointers.ts
+++ b/src/utils/pointers.ts
@@ -1,6 +1,6 @@
 import { EthAddress } from '@dcl/schemas'
 
-const DEFAULT_PROFILE_POINTER_PREFIX = 'default'
+const DEFAULT_PROFILE_POINTER_REGEX = /^default\d+$/
 
 /**
  * Profile pointers are either an address or, for default profiles, a name. Both are matched on the
@@ -11,5 +11,5 @@ export function isAddressPointer(pointer: string): boolean {
 }
 
 export function isDefaultProfilePointer(pointer: string): boolean {
-  return pointer.toLowerCase().startsWith(DEFAULT_PROFILE_POINTER_PREFIX)
+  return DEFAULT_PROFILE_POINTER_REGEX.test(pointer.toLowerCase())
 }

--- a/src/utils/pointers.ts
+++ b/src/utils/pointers.ts
@@ -1,0 +1,15 @@
+import { EthAddress } from '@dcl/schemas'
+
+const DEFAULT_PROFILE_POINTER_PREFIX = 'default'
+
+/**
+ * Profile pointers are either an address or, for default profiles, a name. Both are matched on the
+ * lowercased value, since every layer keys profiles by it.
+ */
+export function isAddressPointer(pointer: string): boolean {
+  return EthAddress.validate(pointer.toLowerCase())
+}
+
+export function isDefaultProfilePointer(pointer: string): boolean {
+  return pointer.toLowerCase().startsWith(DEFAULT_PROFILE_POINTER_PREFIX)
+}

--- a/src/utils/pointers.ts
+++ b/src/utils/pointers.ts
@@ -1,15 +1,9 @@
 import { EthAddress } from '@dcl/schemas'
 
-const DEFAULT_PROFILE_POINTER_REGEX = /^default\d+$/
-
 /**
- * Profile pointers are either an address or, for default profiles, a name. Both are matched on the
- * lowercased value, since every layer keys profiles by it.
+ * Profile pointers are either an address or, for default profiles, a name. Matched on the lowercased
+ * value, since every layer keys profiles by it.
  */
 export function isAddressPointer(pointer: string): boolean {
   return EthAddress.validate(pointer.toLowerCase())
-}
-
-export function isDefaultProfilePointer(pointer: string): boolean {
-  return DEFAULT_PROFILE_POINTER_REGEX.test(pointer.toLowerCase())
 }

--- a/test/integration/profiles-endpoint.spec.ts
+++ b/test/integration/profiles-endpoint.spec.ts
@@ -131,7 +131,7 @@ test('POST /profiles endpoint', async function ({ components, spyComponents }) {
     beforeEach(async function () {
       pointer = '0xcatalystprofile1111111111111111111'
       lambdasProfile = createTestLambdasProfile('bafkreicatalystprofile', pointer, 'CatalystUser')
-      spyComponents.catalyst.getProfiles.mockResolvedValueOnce([lambdasProfile])
+      spyComponents.catalyst.getProfiles.mockResolvedValueOnce(new Map([[pointer, lambdasProfile]]))
       spyComponents.catalyst.convertLambdasProfileToEntity.mockReturnValueOnce(
         profileDbEntityToEntity(
           createProfileDbEntity({
@@ -167,7 +167,7 @@ test('POST /profiles endpoint', async function ({ components, spyComponents }) {
 
     beforeEach(function () {
       pointer = '0xnonexistentprofile11111111111111111'
-      spyComponents.catalyst.getProfiles.mockResolvedValueOnce([])
+      spyComponents.catalyst.getProfiles.mockResolvedValueOnce(new Map())
     })
 
     it('should return an empty array', async function () {

--- a/test/integration/profiles-endpoint.spec.ts
+++ b/test/integration/profiles-endpoint.spec.ts
@@ -162,6 +162,16 @@ test('POST /profiles endpoint', async function ({ components, spyComponents }) {
     })
   })
 
+  describe('when ids is empty', function () {
+    it('should return an empty array', async function () {
+      const response = await fetchLocally('POST', '/profiles', undefined, { ids: [] })
+      const parsedResponse = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(parsedResponse).toEqual([])
+    })
+  })
+
   describe('when no profiles are found', function () {
     let pointer: string
 

--- a/test/integration/profiles-metadata-endpoint.spec.ts
+++ b/test/integration/profiles-metadata-endpoint.spec.ts
@@ -158,6 +158,16 @@ test('POST /profiles/metadata endpoint', async function ({ components, spyCompon
     })
   })
 
+  describe('when ids is empty', function () {
+    it('should return an empty array', async function () {
+      const response = await fetchLocally('POST', '/profiles/metadata', undefined, { ids: [] })
+      const parsedResponse = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(parsedResponse).toEqual([])
+    })
+  })
+
   describe('when no profiles are found', function () {
     let pointer: string
 

--- a/test/integration/profiles-metadata-endpoint.spec.ts
+++ b/test/integration/profiles-metadata-endpoint.spec.ts
@@ -122,7 +122,7 @@ test('POST /profiles/metadata endpoint', async function ({ components, spyCompon
     beforeEach(async function () {
       pointer = '0xcatalystmeta111111111111111111111111'
       lambdasProfile = createTestLambdasProfile('bafkreicatalystmeta', pointer, 'CatalystUser', true)
-      spyComponents.catalyst.getProfiles.mockResolvedValueOnce([lambdasProfile])
+      spyComponents.catalyst.getProfiles.mockResolvedValueOnce(new Map([[pointer, lambdasProfile]]))
       spyComponents.catalyst.convertLambdasProfileToEntity.mockReturnValueOnce(
         profileDbEntityToEntity(
           createProfileDbEntity({
@@ -163,7 +163,7 @@ test('POST /profiles/metadata endpoint', async function ({ components, spyCompon
 
     beforeEach(function () {
       pointer = '0xnonexistent1111111111111111111111111'
-      spyComponents.catalyst.getProfiles.mockResolvedValueOnce([])
+      spyComponents.catalyst.getProfiles.mockResolvedValueOnce(new Map())
     })
 
     it('should return an empty array', async function () {

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -60,6 +60,31 @@ describe('catalyst adapter', () => {
       })
     })
 
+    describe('and a default profile name is requested', () => {
+      beforeEach(() => {
+        // A default profile reports the deployer address, not the name it was asked for
+        getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile('0x1337000000000000000000000000000000001337')])
+      })
+
+      it('should not look it up, since the response could not be attributed to it', async () => {
+        await component.getProfiles(['default5'])
+
+        expect(getAvatarsDetailsByPost).not.toHaveBeenCalled()
+      })
+
+      it('should not return a profile under the address it would have reported', async () => {
+        const result = await component.getProfiles(['default5'])
+
+        expect(result.size).toEqual(0)
+      })
+
+      it('should still look up the address pointers requested alongside it', async () => {
+        await component.getProfiles(['default5', requestedPointer])
+
+        expect(getAvatarsDetailsByPost).toHaveBeenCalledWith({ ids: [requestedPointer] })
+      })
+    })
+
     describe('and the requested pointer is checksummed', () => {
       beforeEach(() => {
         getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile(requestedPointer.toUpperCase())])

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -140,7 +140,15 @@ describe('catalyst adapter', () => {
       })
 
       it('should not request them at all', async () => {
-        await component.getProfiles(['not-a-pointer', 'another-one', ''])
+        await component.getProfiles([
+          'not-a-pointer',
+          'another-one',
+          '',
+          'default',
+          'defaultfoo',
+          'default-1',
+          'default_1'
+        ])
 
         expect(getAvatarsDetailsByPost).not.toHaveBeenCalled()
       })

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -33,7 +33,6 @@ function createLambdasProfile(address: string, timestamp = 1000): Profile {
 
 describe('catalyst adapter', () => {
   const requestedPointer = '0x1111111111111111111111111111111111111111'
-  const otherPointer = '0x2222222222222222222222222222222222222222'
   let component: ICatalystComponent
 
   beforeEach(async () => {
@@ -72,88 +71,11 @@ describe('catalyst adapter', () => {
         expect(result.get(requestedPointer)).toBeDefined()
       })
     })
-
-    describe('and a name pointer is requested', () => {
-      const namePointer = 'default5'
-
-      beforeEach(() => {
-        // A default profile carries the deployer address, unrelated to the requested name
-        getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile(otherPointer)])
-      })
-
-      it('should key the profile by the requested name pointer', async () => {
-        const result = await component.getProfiles([namePointer])
-
-        expect(result.get(namePointer)).toBeDefined()
-      })
-
-      it('should not key it by the address in its metadata', async () => {
-        const result = await component.getProfiles([namePointer])
-
-        expect(result.has(otherPointer)).toBe(false)
-      })
-
-      it('should request it on its own so it can be correlated', async () => {
-        await component.getProfiles([namePointer, requestedPointer])
-
-        expect(getAvatarsDetailsByPost).toHaveBeenCalledWith({ ids: [namePointer] })
-        expect(getAvatarsDetailsByPost).toHaveBeenCalledWith({ ids: [requestedPointer] })
-      })
-    })
-
-    describe('and pointers are neither an address nor a default profile name', () => {
-      beforeEach(() => {
-        getAvatarsDetailsByPost.mockResolvedValue([])
-      })
-
-      it('should not request them at all', async () => {
-        await component.getProfiles([
-          'not-a-pointer',
-          'another-one',
-          '',
-          'default',
-          'defaultfoo',
-          'default-1',
-          'default_1'
-        ])
-
-        expect(getAvatarsDetailsByPost).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('and several name pointers are requested', () => {
-      const namePointers = Array.from({ length: 12 }, (_, index) => `default${index}`)
-
-      beforeEach(() => {
-        getAvatarsDetailsByPost.mockResolvedValue([])
-      })
-
-      it('should look every one of them up rather than truncate', async () => {
-        await component.getProfiles(namePointers)
-
-        expect(getAvatarsDetailsByPost).toHaveBeenCalledTimes(namePointers.length)
-      })
-    })
-
-    describe('and a name pointer request returns more than one profile', () => {
-      beforeEach(() => {
-        getAvatarsDetailsByPost.mockResolvedValue([
-          createLambdasProfile(otherPointer),
-          createLambdasProfile(requestedPointer)
-        ])
-      })
-
-      it('should drop it rather than guess which one was meant', async () => {
-        const result = await component.getProfiles(['default5'])
-
-        expect(result.size).toEqual(0)
-      })
-    })
   })
 
   describe('when converting a lambdas profile to an entity', () => {
-    it('should point the entity at the supplied pointer', () => {
-      const entity = component.convertLambdasProfileToEntity(createLambdasProfile(requestedPointer), requestedPointer)
+    it('should point the entity at the address it reports', () => {
+      const entity = component.convertLambdasProfileToEntity(createLambdasProfile(requestedPointer))
 
       expect(entity?.pointers).toEqual([requestedPointer])
     })

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -146,17 +146,17 @@ describe('catalyst adapter', () => {
       })
     })
 
-    describe('and more name pointers are requested than the lookup limit', () => {
-      const namePointers = Array.from({ length: 60 }, (_, index) => `default${index}`)
+    describe('and several name pointers are requested', () => {
+      const namePointers = Array.from({ length: 12 }, (_, index) => `default${index}`)
 
       beforeEach(() => {
         getAvatarsDetailsByPost.mockResolvedValue([])
       })
 
-      it('should bound the amount of outbound requests', async () => {
+      it('should look every one of them up rather than truncate', async () => {
         await component.getProfiles(namePointers)
 
-        expect(getAvatarsDetailsByPost.mock.calls.length).toBeLessThanOrEqual(25)
+        expect(getAvatarsDetailsByPost).toHaveBeenCalledTimes(namePointers.length)
       })
     })
 

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -105,6 +105,49 @@ describe('catalyst adapter', () => {
         expect(result.get(requestedPointer)).toBeDefined()
       })
     })
+
+    describe('and a name pointer is requested', () => {
+      const namePointer = 'default5'
+
+      beforeEach(() => {
+        // A default profile carries the deployer address, unrelated to the requested name
+        getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile(otherPointer)])
+      })
+
+      it('should key the profile by the requested name pointer', async () => {
+        const result = await component.getProfiles([namePointer])
+
+        expect(result.get(namePointer)).toBeDefined()
+      })
+
+      it('should not key it by the address in its metadata', async () => {
+        const result = await component.getProfiles([namePointer])
+
+        expect(result.has(otherPointer)).toBe(false)
+      })
+
+      it('should request it on its own so it can be correlated', async () => {
+        await component.getProfiles([namePointer, requestedPointer])
+
+        expect(getAvatarsDetailsByPost).toHaveBeenCalledWith({ ids: [namePointer] })
+        expect(getAvatarsDetailsByPost).toHaveBeenCalledWith({ ids: [requestedPointer] })
+      })
+    })
+
+    describe('and a name pointer request returns more than one profile', () => {
+      beforeEach(() => {
+        getAvatarsDetailsByPost.mockResolvedValue([
+          createLambdasProfile(otherPointer),
+          createLambdasProfile(requestedPointer)
+        ])
+      })
+
+      it('should drop it rather than guess which one was meant', async () => {
+        const result = await component.getProfiles(['default5'])
+
+        expect(result.size).toEqual(0)
+      })
+    })
   })
 
   describe('when converting a lambdas profile to an entity', () => {

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -134,6 +134,32 @@ describe('catalyst adapter', () => {
       })
     })
 
+    describe('and pointers are neither an address nor a default profile name', () => {
+      beforeEach(() => {
+        getAvatarsDetailsByPost.mockResolvedValue([])
+      })
+
+      it('should not request them at all', async () => {
+        await component.getProfiles(['not-a-pointer', 'another-one', ''])
+
+        expect(getAvatarsDetailsByPost).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and more name pointers are requested than the lookup limit', () => {
+      const namePointers = Array.from({ length: 60 }, (_, index) => `default${index}`)
+
+      beforeEach(() => {
+        getAvatarsDetailsByPost.mockResolvedValue([])
+      })
+
+      it('should bound the amount of outbound requests', async () => {
+        await component.getProfiles(namePointers)
+
+        expect(getAvatarsDetailsByPost.mock.calls.length).toBeLessThanOrEqual(25)
+      })
+    })
+
     describe('and a name pointer request returns more than one profile', () => {
       beforeEach(() => {
         getAvatarsDetailsByPost.mockResolvedValue([

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -49,39 +49,6 @@ describe('catalyst adapter', () => {
   })
 
   describe('when fetching profiles', () => {
-    describe('and a returned profile has an address that was not requested', () => {
-      beforeEach(() => {
-        getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile(otherPointer)])
-      })
-
-      it('should not return it under that address', async () => {
-        const result = await component.getProfiles([requestedPointer])
-
-        expect(result.has(otherPointer)).toBe(false)
-      })
-
-      it('should return no profiles at all', async () => {
-        const result = await component.getProfiles([requestedPointer])
-
-        expect(result.size).toEqual(0)
-      })
-    })
-
-    describe('and two returned profiles have the same requested address', () => {
-      beforeEach(() => {
-        getAvatarsDetailsByPost.mockResolvedValue([
-          createLambdasProfile(requestedPointer, 1000),
-          createLambdasProfile(requestedPointer, 2000)
-        ])
-      })
-
-      it('should drop the ambiguous address rather than pick a winner', async () => {
-        const result = await component.getProfiles([requestedPointer])
-
-        expect(result.has(requestedPointer)).toBe(false)
-      })
-    })
-
     describe('and a returned profile matches the requested address', () => {
       beforeEach(() => {
         getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile(requestedPointer)])
@@ -185,12 +152,10 @@ describe('catalyst adapter', () => {
   })
 
   describe('when converting a lambdas profile to an entity', () => {
-    describe('and the metadata has a different address than the supplied pointer', () => {
-      it('should point the entity at the supplied pointer', () => {
-        const entity = component.convertLambdasProfileToEntity(createLambdasProfile(otherPointer), requestedPointer)
+    it('should point the entity at the supplied pointer', () => {
+      const entity = component.convertLambdasProfileToEntity(createLambdasProfile(requestedPointer), requestedPointer)
 
-        expect(entity?.pointers).toEqual([requestedPointer])
-      })
+      expect(entity?.pointers).toEqual([requestedPointer])
     })
   })
 })

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -99,6 +99,40 @@ describe('catalyst adapter', () => {
   })
 
   describe('when converting a lambdas profile to an entity', () => {
+    describe('and the metadata carries an identity other than the address it reports', () => {
+      let profile: Profile
+
+      beforeEach(() => {
+        profile = createLambdasProfile(requestedPointer)
+        // an older node serves the deployed metadata, where the two can disagree
+        ;(profile.avatars as any)[0].userId = '0x9999999999999999999999999999999999999999'
+      })
+
+      it('should settle the userId to the pointer the entity is keyed by', () => {
+        const entity = component.convertLambdasProfileToEntity(profile)
+
+        expect((entity?.metadata as Profile).avatars?.[0].userId).toEqual(requestedPointer)
+      })
+    })
+
+    describe('and the reported address is checksummed', () => {
+      let entity: ReturnType<ICatalystComponent['convertLambdasProfileToEntity']>
+
+      beforeEach(() => {
+        entity = component.convertLambdasProfileToEntity(createLambdasProfile(requestedPointer.toUpperCase()))
+      })
+
+      it('should key the entity by the lowercased pointer', () => {
+        expect(entity?.pointers).toEqual([requestedPointer])
+      })
+
+      it('should settle the identity to the same lowercased value', () => {
+        const avatar = (entity?.metadata as Profile).avatars?.[0]
+
+        expect([avatar?.ethAddress, avatar?.userId]).toEqual([requestedPointer, requestedPointer])
+      })
+    })
+
     it('should point the entity at the address it reports', () => {
       const entity = component.convertLambdasProfileToEntity(createLambdasProfile(requestedPointer))
 

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -1,0 +1,119 @@
+import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
+import { createCatalystAdapter } from '../../../src/adapters/catalyst'
+import { ICatalystComponent } from '../../../src/types'
+import { createConfigMockComponent } from '../mocks/config'
+import { createLogMockComponent } from '../mocks/logs'
+
+const getAvatarsDetailsByPost = jest.fn()
+
+jest.mock('dcl-catalyst-client', () => ({
+  createContentClient: jest.fn().mockReturnValue({}),
+  createLambdasClient: jest.fn().mockImplementation(() => ({ getAvatarsDetailsByPost }))
+}))
+
+function createLambdasProfile(address: string, timestamp = 1000): Profile {
+  return {
+    timestamp,
+    avatars: [
+      {
+        name: 'test',
+        hasClaimedName: false,
+        ethAddress: address,
+        userId: address,
+        avatar: {
+          snapshots: {
+            body: `https://peer.decentraland.org/content/entities/bafkrei${address.slice(-4)}/body.png`,
+            face256: `https://peer.decentraland.org/content/entities/bafkrei${address.slice(-4)}/face.png`
+          }
+        }
+      }
+    ]
+  } as unknown as Profile
+}
+
+describe('catalyst adapter', () => {
+  const requestedPointer = '0x1111111111111111111111111111111111111111'
+  const otherPointer = '0x2222222222222222222222222222222222222222'
+  let component: ICatalystComponent
+
+  beforeEach(async () => {
+    const config = createConfigMockComponent()
+    ;(config.requireString as jest.Mock).mockResolvedValue('https://peer.decentraland.org')
+    getAvatarsDetailsByPost.mockReset()
+
+    component = await createCatalystAdapter({
+      config,
+      logs: createLogMockComponent() as any,
+      fetch: { fetch: jest.fn() } as any
+    })
+  })
+
+  describe('when fetching profiles', () => {
+    describe('and a returned profile has an address that was not requested', () => {
+      beforeEach(() => {
+        getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile(otherPointer)])
+      })
+
+      it('should not return it under that address', async () => {
+        const result = await component.getProfiles([requestedPointer])
+
+        expect(result.has(otherPointer)).toBe(false)
+      })
+
+      it('should return no profiles at all', async () => {
+        const result = await component.getProfiles([requestedPointer])
+
+        expect(result.size).toEqual(0)
+      })
+    })
+
+    describe('and two returned profiles have the same requested address', () => {
+      beforeEach(() => {
+        getAvatarsDetailsByPost.mockResolvedValue([
+          createLambdasProfile(requestedPointer, 1000),
+          createLambdasProfile(requestedPointer, 2000)
+        ])
+      })
+
+      it('should drop the ambiguous address rather than pick a winner', async () => {
+        const result = await component.getProfiles([requestedPointer])
+
+        expect(result.has(requestedPointer)).toBe(false)
+      })
+    })
+
+    describe('and a returned profile matches the requested address', () => {
+      beforeEach(() => {
+        getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile(requestedPointer)])
+      })
+
+      it('should key it by the requested pointer', async () => {
+        const result = await component.getProfiles([requestedPointer])
+
+        expect(result.get(requestedPointer)).toBeDefined()
+      })
+    })
+
+    describe('and the requested pointer is checksummed', () => {
+      beforeEach(() => {
+        getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile(requestedPointer.toUpperCase())])
+      })
+
+      it('should key it by the lowercased pointer', async () => {
+        const result = await component.getProfiles([requestedPointer.toUpperCase()])
+
+        expect(result.get(requestedPointer)).toBeDefined()
+      })
+    })
+  })
+
+  describe('when converting a lambdas profile to an entity', () => {
+    describe('and the metadata has a different address than the supplied pointer', () => {
+      it('should point the entity at the supplied pointer', () => {
+        const entity = component.convertLambdasProfileToEntity(createLambdasProfile(otherPointer), requestedPointer)
+
+        expect(entity?.pointers).toEqual([requestedPointer])
+      })
+    })
+  })
+})

--- a/test/unit/controllers/schemas/profiles.spec.ts
+++ b/test/unit/controllers/schemas/profiles.spec.ts
@@ -1,5 +1,5 @@
 import { InvalidRequestError } from '@dcl/http-commons'
-import { MAX_PROFILE_POINTERS_PER_REQUEST, parseProfilePointers } from '../../../../src/controllers/schemas/profiles'
+import { parseProfilePointers } from '../../../../src/controllers/schemas/profiles'
 
 describe('profile pointers request schema', () => {
   describe('when the body holds an array of pointers', () => {
@@ -35,32 +35,6 @@ describe('profile pointers request schema', () => {
   describe('when the ids property holds an empty string', () => {
     it('should throw an invalid request error', () => {
       expect(() => parseProfilePointers({ ids: [''] })).toThrow(InvalidRequestError)
-    })
-  })
-
-  describe('when more pointers than the limit are requested', () => {
-    let ids: string[]
-
-    beforeEach(() => {
-      ids = Array.from({ length: MAX_PROFILE_POINTERS_PER_REQUEST + 1 }, (_, index) => `0x${index}`)
-    })
-
-    it('should throw an invalid request error naming the limit', () => {
-      expect(() => parseProfilePointers({ ids })).toThrow(
-        `A maximum of ${MAX_PROFILE_POINTERS_PER_REQUEST} ids can be requested at once, got ${ids.length}`
-      )
-    })
-  })
-
-  describe('when exactly the limit is requested', () => {
-    let ids: string[]
-
-    beforeEach(() => {
-      ids = Array.from({ length: MAX_PROFILE_POINTERS_PER_REQUEST }, (_, index) => `0x${index}`)
-    })
-
-    it('should return them', () => {
-      expect(parseProfilePointers({ ids })).toHaveLength(MAX_PROFILE_POINTERS_PER_REQUEST)
     })
   })
 

--- a/test/unit/controllers/schemas/profiles.spec.ts
+++ b/test/unit/controllers/schemas/profiles.spec.ts
@@ -1,5 +1,9 @@
 import { InvalidRequestError } from '@dcl/http-commons'
-import { MAX_PROFILE_POINTERS_PER_REQUEST, parseProfilePointers } from '../../../../src/controllers/schemas/profiles'
+import {
+  MAX_NAME_POINTERS_PER_REQUEST,
+  MAX_PROFILE_POINTERS_PER_REQUEST,
+  parseProfilePointers
+} from '../../../../src/controllers/schemas/profiles'
 
 describe('profile pointers request schema', () => {
   describe('when the body holds an array of pointers', () => {
@@ -55,6 +59,48 @@ describe('profile pointers request schema', () => {
 
     it('should return them', () => {
       expect(parseProfilePointers({ ids })).toHaveLength(MAX_PROFILE_POINTERS_PER_REQUEST)
+    })
+  })
+
+  describe('when more default profile names than their limit are requested', () => {
+    let ids: string[]
+
+    beforeEach(() => {
+      ids = Array.from({ length: MAX_NAME_POINTERS_PER_REQUEST + 1 }, (_, index) => `default${index}`)
+    })
+
+    it('should throw an invalid request error naming the limit', () => {
+      expect(() => parseProfilePointers({ ids })).toThrow(
+        `A maximum of ${MAX_NAME_POINTERS_PER_REQUEST} default profile ids can be requested at once, got ${ids.length}`
+      )
+    })
+  })
+
+  describe('when exactly the default profile name limit is requested', () => {
+    let ids: string[]
+
+    beforeEach(() => {
+      ids = Array.from({ length: MAX_NAME_POINTERS_PER_REQUEST }, (_, index) => `default${index}`)
+    })
+
+    it('should return them', () => {
+      expect(parseProfilePointers({ ids })).toHaveLength(MAX_NAME_POINTERS_PER_REQUEST)
+    })
+  })
+
+  describe('when many addresses are requested alongside a few default profile names', () => {
+    let ids: string[]
+
+    beforeEach(() => {
+      ids = [
+        ...Array.from({ length: 400 }, (_, index) => `0x${index.toString().padStart(40, '0')}`),
+        'default1',
+        'default2'
+      ]
+    })
+
+    it('should return them, since only the names are limited', () => {
+      expect(parseProfilePointers({ ids })).toHaveLength(ids.length)
     })
   })
 })

--- a/test/unit/controllers/schemas/profiles.spec.ts
+++ b/test/unit/controllers/schemas/profiles.spec.ts
@@ -12,6 +12,12 @@ describe('profile pointers request schema', () => {
     })
   })
 
+  describe('when the ids property is empty', () => {
+    it('should return an empty array', () => {
+      expect(parseProfilePointers({ ids: [] })).toEqual([])
+    })
+  })
+
   describe('when the ids property is missing', () => {
     it('should throw an invalid request error', () => {
       expect(() => parseProfilePointers({})).toThrow(InvalidRequestError)
@@ -73,6 +79,18 @@ describe('profile pointers request schema', () => {
       expect(() => parseProfilePointers({ ids })).toThrow(
         `A maximum of ${MAX_NAME_POINTERS_PER_REQUEST} default profile ids can be requested at once, got ${ids.length}`
       )
+    })
+  })
+
+  describe('when more malformed default-looking ids than the default profile name limit are requested', () => {
+    let ids: string[]
+
+    beforeEach(() => {
+      ids = Array.from({ length: MAX_NAME_POINTERS_PER_REQUEST + 1 }, (_, index) => `defaultfoo${index}`)
+    })
+
+    it('should return them because they are ignored ids rather than default profile names', () => {
+      expect(parseProfilePointers({ ids })).toHaveLength(ids.length)
     })
   })
 

--- a/test/unit/controllers/schemas/profiles.spec.ts
+++ b/test/unit/controllers/schemas/profiles.spec.ts
@@ -1,0 +1,60 @@
+import { InvalidRequestError } from '@dcl/http-commons'
+import { MAX_PROFILE_POINTERS_PER_REQUEST, parseProfilePointers } from '../../../../src/controllers/schemas/profiles'
+
+describe('profile pointers request schema', () => {
+  describe('when the body holds an array of pointers', () => {
+    it('should return them', () => {
+      expect(parseProfilePointers({ ids: ['0x1', 'default5'] })).toEqual(['0x1', 'default5'])
+    })
+  })
+
+  describe('when the ids property is missing', () => {
+    it('should throw an invalid request error', () => {
+      expect(() => parseProfilePointers({})).toThrow(InvalidRequestError)
+    })
+  })
+
+  describe('when the ids property is not an array', () => {
+    it('should throw an invalid request error', () => {
+      expect(() => parseProfilePointers({ ids: '0x1' })).toThrow(InvalidRequestError)
+    })
+  })
+
+  describe('when the ids property holds a value that is not a string', () => {
+    it('should throw an invalid request error', () => {
+      expect(() => parseProfilePointers({ ids: ['0x1', 42] })).toThrow(InvalidRequestError)
+    })
+  })
+
+  describe('when the ids property holds an empty string', () => {
+    it('should throw an invalid request error', () => {
+      expect(() => parseProfilePointers({ ids: [''] })).toThrow(InvalidRequestError)
+    })
+  })
+
+  describe('when more pointers than the limit are requested', () => {
+    let ids: string[]
+
+    beforeEach(() => {
+      ids = Array.from({ length: MAX_PROFILE_POINTERS_PER_REQUEST + 1 }, (_, index) => `0x${index}`)
+    })
+
+    it('should throw an invalid request error naming the limit', () => {
+      expect(() => parseProfilePointers({ ids })).toThrow(
+        `A maximum of ${MAX_PROFILE_POINTERS_PER_REQUEST} ids can be requested at once, got ${ids.length}`
+      )
+    })
+  })
+
+  describe('when exactly the limit is requested', () => {
+    let ids: string[]
+
+    beforeEach(() => {
+      ids = Array.from({ length: MAX_PROFILE_POINTERS_PER_REQUEST }, (_, index) => `0x${index}`)
+    })
+
+    it('should return them', () => {
+      expect(parseProfilePointers({ ids })).toHaveLength(MAX_PROFILE_POINTERS_PER_REQUEST)
+    })
+  })
+})

--- a/test/unit/controllers/schemas/profiles.spec.ts
+++ b/test/unit/controllers/schemas/profiles.spec.ts
@@ -1,9 +1,5 @@
 import { InvalidRequestError } from '@dcl/http-commons'
-import {
-  MAX_NAME_POINTERS_PER_REQUEST,
-  MAX_PROFILE_POINTERS_PER_REQUEST,
-  parseProfilePointers
-} from '../../../../src/controllers/schemas/profiles'
+import { MAX_PROFILE_POINTERS_PER_REQUEST, parseProfilePointers } from '../../../../src/controllers/schemas/profiles'
 
 describe('profile pointers request schema', () => {
   describe('when the body holds an array of pointers', () => {
@@ -65,44 +61,6 @@ describe('profile pointers request schema', () => {
 
     it('should return them', () => {
       expect(parseProfilePointers({ ids })).toHaveLength(MAX_PROFILE_POINTERS_PER_REQUEST)
-    })
-  })
-
-  describe('when more default profile names than their limit are requested', () => {
-    let ids: string[]
-
-    beforeEach(() => {
-      ids = Array.from({ length: MAX_NAME_POINTERS_PER_REQUEST + 1 }, (_, index) => `default${index}`)
-    })
-
-    it('should throw an invalid request error naming the limit', () => {
-      expect(() => parseProfilePointers({ ids })).toThrow(
-        `A maximum of ${MAX_NAME_POINTERS_PER_REQUEST} default profile ids can be requested at once, got ${ids.length}`
-      )
-    })
-  })
-
-  describe('when more malformed default-looking ids than the default profile name limit are requested', () => {
-    let ids: string[]
-
-    beforeEach(() => {
-      ids = Array.from({ length: MAX_NAME_POINTERS_PER_REQUEST + 1 }, (_, index) => `defaultfoo${index}`)
-    })
-
-    it('should return them because they are ignored ids rather than default profile names', () => {
-      expect(parseProfilePointers({ ids })).toHaveLength(ids.length)
-    })
-  })
-
-  describe('when exactly the default profile name limit is requested', () => {
-    let ids: string[]
-
-    beforeEach(() => {
-      ids = Array.from({ length: MAX_NAME_POINTERS_PER_REQUEST }, (_, index) => `default${index}`)
-    })
-
-    it('should return them', () => {
-      expect(parseProfilePointers({ ids })).toHaveLength(MAX_NAME_POINTERS_PER_REQUEST)
     })
   })
 

--- a/test/unit/logic/profile-retriever.spec.ts
+++ b/test/unit/logic/profile-retriever.spec.ts
@@ -201,6 +201,12 @@ describe('profile retriever', () => {
           expect(result.has(unrequestedPointer)).toBe(false)
         })
 
+        it('should not persist it as a side effect of the request', async () => {
+          await component.getProfiles([pointerA])
+
+          expect(mockEntityPersister.persistEntity).not.toHaveBeenCalled()
+        })
+
         it('should report the requested pointer as not found', async () => {
           const result = await component.getProfiles([pointerA])
 

--- a/test/unit/logic/profile-retriever.spec.ts
+++ b/test/unit/logic/profile-retriever.spec.ts
@@ -176,6 +176,37 @@ describe('profile retriever', () => {
           expect(mockCatalyst.getProfiles).toHaveBeenCalledWith([pointerB])
         })
       })
+
+      describe('and the catalyst answers with a profile for a pointer that was not requested', () => {
+        let pointerA: string
+        let unrequestedPointer: string
+
+        beforeEach(() => {
+          pointerA = '0x123'
+          unrequestedPointer = '0x456'
+          mockDb.getProfilesByPointers = jest.fn().mockResolvedValueOnce([])
+          mockCatalyst.getProfiles = jest
+            .fn()
+            .mockResolvedValueOnce(
+              new Map([[unrequestedPointer, createTestLambdasProfile('bafkreiunrequested', unrequestedPointer)]])
+            )
+          mockCatalyst.convertLambdasProfileToEntity = jest
+            .fn()
+            .mockReturnValue(createProfileEntity({ id: 'bafkreiunrequested', pointers: [unrequestedPointer] }))
+        })
+
+        it('should leave it out of the result', async () => {
+          const result = await component.getProfiles([pointerA])
+
+          expect(result.has(unrequestedPointer)).toBe(false)
+        })
+
+        it('should report the requested pointer as not found', async () => {
+          const result = await component.getProfiles([pointerA])
+
+          expect(result.size).toEqual(0)
+        })
+      })
     })
 
     describe('when some profiles are found in the cache and some are not', () => {

--- a/test/unit/logic/profile-retriever.spec.ts
+++ b/test/unit/logic/profile-retriever.spec.ts
@@ -75,22 +75,22 @@ describe('profile retriever', () => {
             pointerB = '0x456'
             entityIdA = 'bafkreientitya'
             entityIdB = 'bafkreientityb'
-            mockCatalyst.getProfiles = jest
+            mockCatalyst.getProfiles = jest.fn().mockResolvedValueOnce(
+              new Map([
+                [pointerA, createTestLambdasProfile(entityIdA, pointerA)],
+                [pointerB, createTestLambdasProfile(entityIdB, pointerB)]
+              ])
+            )
+            mockCatalyst.convertLambdasProfileToEntity = jest
               .fn()
-              .mockResolvedValueOnce(
-                new Map([
-                  [pointerA, createTestLambdasProfile(entityIdA, pointerA)],
-                  [pointerB, createTestLambdasProfile(entityIdB, pointerB)]
-                ])
-              )
-            mockCatalyst.convertLambdasProfileToEntity = jest.fn().mockImplementation((_profile: Profile, pointer: string) => {
-              if (pointer.toLowerCase() === pointerA.toLowerCase()) {
-                return createProfileEntity({ id: entityIdA, pointers: [pointerA] })
-              } else if (pointer.toLowerCase() === pointerB.toLowerCase()) {
-                return createProfileEntity({ id: entityIdB, pointers: [pointerB] })
-              }
-              return null
-            })
+              .mockImplementation((_profile: Profile, pointer: string) => {
+                if (pointer.toLowerCase() === pointerA.toLowerCase()) {
+                  return createProfileEntity({ id: entityIdA, pointers: [pointerA] })
+                } else if (pointer.toLowerCase() === pointerB.toLowerCase()) {
+                  return createProfileEntity({ id: entityIdB, pointers: [pointerB] })
+                }
+                return null
+              })
           })
 
           it('should fetch the profiles from the catalyst and return them', async () => {

--- a/test/unit/logic/profile-retriever.spec.ts
+++ b/test/unit/logic/profile-retriever.spec.ts
@@ -77,15 +77,16 @@ describe('profile retriever', () => {
             entityIdB = 'bafkreientityb'
             mockCatalyst.getProfiles = jest
               .fn()
-              .mockResolvedValueOnce([
-                createTestLambdasProfile(entityIdA, pointerA),
-                createTestLambdasProfile(entityIdB, pointerB)
-              ])
-            mockCatalyst.convertLambdasProfileToEntity = jest.fn().mockImplementation((profile: Profile) => {
-              const pointer = profile.avatars?.[0]?.ethAddress?.toLowerCase()
-              if (pointer === pointerA.toLowerCase()) {
+              .mockResolvedValueOnce(
+                new Map([
+                  [pointerA, createTestLambdasProfile(entityIdA, pointerA)],
+                  [pointerB, createTestLambdasProfile(entityIdB, pointerB)]
+                ])
+              )
+            mockCatalyst.convertLambdasProfileToEntity = jest.fn().mockImplementation((_profile: Profile, pointer: string) => {
+              if (pointer.toLowerCase() === pointerA.toLowerCase()) {
                 return createProfileEntity({ id: entityIdA, pointers: [pointerA] })
-              } else if (pointer === pointerB.toLowerCase()) {
+              } else if (pointer.toLowerCase() === pointerB.toLowerCase()) {
                 return createProfileEntity({ id: entityIdB, pointers: [pointerB] })
               }
               return null
@@ -148,7 +149,9 @@ describe('profile retriever', () => {
           entityIdB = 'bafkreientityb'
           profilesFromDB = [createProfileDbEntity({ id: pointerA, pointer: pointerA })]
           mockDb.getProfilesByPointers = jest.fn().mockResolvedValueOnce(profilesFromDB)
-          mockCatalyst.getProfiles = jest.fn().mockResolvedValueOnce([createTestLambdasProfile(entityIdB, pointerB)])
+          mockCatalyst.getProfiles = jest
+            .fn()
+            .mockResolvedValueOnce(new Map([[pointerB, createTestLambdasProfile(entityIdB, pointerB)]]))
           mockCatalyst.convertLambdasProfileToEntity = jest.fn().mockImplementation((profile: Profile) => {
             const pointer = profile.avatars?.[0]?.ethAddress?.toLowerCase()
             if (pointer === pointerB.toLowerCase()) {
@@ -219,7 +222,9 @@ describe('profile retriever', () => {
       describe('and the rest of profiles are found in the catalyst', () => {
         const entityIdB = 'bafkreientityb'
         beforeEach(() => {
-          mockCatalyst.getProfiles = jest.fn().mockResolvedValueOnce([createTestLambdasProfile(entityIdB, pointerB)])
+          mockCatalyst.getProfiles = jest
+            .fn()
+            .mockResolvedValueOnce(new Map([[pointerB, createTestLambdasProfile(entityIdB, pointerB)]]))
           mockCatalyst.convertLambdasProfileToEntity = jest.fn().mockImplementation((profile: Profile) => {
             const pointer = profile.avatars?.[0]?.ethAddress?.toLowerCase()
             if (pointer === pointerB.toLowerCase()) {

--- a/test/unit/logic/profile-retriever.spec.ts
+++ b/test/unit/logic/profile-retriever.spec.ts
@@ -81,16 +81,15 @@ describe('profile retriever', () => {
                 [pointerB, createTestLambdasProfile(entityIdB, pointerB)]
               ])
             )
-            mockCatalyst.convertLambdasProfileToEntity = jest
-              .fn()
-              .mockImplementation((_profile: Profile, pointer: string) => {
-                if (pointer.toLowerCase() === pointerA.toLowerCase()) {
-                  return createProfileEntity({ id: entityIdA, pointers: [pointerA] })
-                } else if (pointer.toLowerCase() === pointerB.toLowerCase()) {
-                  return createProfileEntity({ id: entityIdB, pointers: [pointerB] })
-                }
-                return null
-              })
+            mockCatalyst.convertLambdasProfileToEntity = jest.fn().mockImplementation((profile: Profile) => {
+              const pointer = profile.avatars?.[0]?.ethAddress?.toLowerCase()
+              if (pointer === pointerA.toLowerCase()) {
+                return createProfileEntity({ id: entityIdA, pointers: [pointerA] })
+              } else if (pointer === pointerB.toLowerCase()) {
+                return createProfileEntity({ id: entityIdB, pointers: [pointerB] })
+              }
+              return null
+            })
           })
 
           it('should fetch the profiles from the catalyst and return them', async () => {

--- a/test/unit/logic/sync/ownership-validator-job.spec.ts
+++ b/test/unit/logic/sync/ownership-validator-job.spec.ts
@@ -116,6 +116,26 @@ describe('ownership validator job', () => {
           pointers = ['0x1234567890123456789012345678901234567890']
         })
 
+        describe('and a cached pointer is a default profile name', () => {
+          let warn: jest.Mock
+
+          beforeEach(async () => {
+            warn = (mockLogs.getLogger as jest.Mock)().warn as jest.Mock
+            warn.mockClear()
+            ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(['default5'])
+            ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce(new Map())
+
+            await component.start?.(createStartOptions())
+            await jest.advanceTimersByTimeAsync(0)
+          })
+
+          it('should not warn about it, since it cannot be validated by design', () => {
+            expect(warn).not.toHaveBeenCalledWith('Skipping validation, no matching profile returned', {
+              pointer: 'default5'
+            })
+          })
+        })
+
         describe('and fetching profiles from catalyst returns empty', () => {
           beforeEach(async () => {
             ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(pointers)

--- a/test/unit/logic/sync/ownership-validator-job.spec.ts
+++ b/test/unit/logic/sync/ownership-validator-job.spec.ts
@@ -119,7 +119,7 @@ describe('ownership validator job', () => {
         describe('and fetching profiles from catalyst returns empty', () => {
           beforeEach(async () => {
             ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(pointers)
-            ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce([])
+            ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce(new Map())
 
             await component.start?.(createStartOptions())
             await jest.advanceTimersByTimeAsync(0)
@@ -172,7 +172,7 @@ describe('ownership validator job', () => {
               })
               ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(pointers)
               ;(mockProfilesCache.getMany as jest.Mock).mockReturnValueOnce(new Map([[pointers[0], storedEntity]]))
-              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce([fetchedProfile])
+              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce(new Map([[pointers[0], fetchedProfile]]))
 
               await component.start?.(createStartOptions())
               await jest.advanceTimersByTimeAsync(0)
@@ -210,7 +210,7 @@ describe('ownership validator job', () => {
               })
               ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(pointers)
               ;(mockProfilesCache.getMany as jest.Mock).mockReturnValueOnce(new Map([[pointers[0], storedEntity]]))
-              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce([fetchedProfile])
+              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce(new Map([[pointers[0], fetchedProfile]]))
               ;(mockCatalyst.convertLambdasProfileToEntity as jest.Mock).mockReturnValueOnce(
                 createProfileEntity({
                   id: newEntityId,
@@ -271,7 +271,7 @@ describe('ownership validator job', () => {
               })
               ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(pointers)
               ;(mockProfilesCache.getMany as jest.Mock).mockReturnValueOnce(new Map([[pointers[0], storedEntity]]))
-              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce([fetchedProfile])
+              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce(new Map([[pointers[0], fetchedProfile]]))
               ;(mockCatalyst.convertLambdasProfileToEntity as jest.Mock).mockReturnValueOnce(
                 createProfileEntity({
                   id: entityId,
@@ -340,7 +340,7 @@ describe('ownership validator job', () => {
               })
               ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(pointers)
               ;(mockProfilesCache.getMany as jest.Mock).mockReturnValueOnce(new Map([[pointers[0], storedEntity]]))
-              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce([fetchedProfile])
+              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce(new Map([[pointers[0], fetchedProfile]]))
               ;(mockCatalyst.convertLambdasProfileToEntity as jest.Mock).mockReturnValueOnce(
                 createProfileEntity({
                   id: entityId,
@@ -407,7 +407,7 @@ describe('ownership validator job', () => {
               })
               ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(pointers)
               ;(mockProfilesCache.getMany as jest.Mock).mockReturnValueOnce(new Map([[pointers[0], storedEntity]]))
-              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce([fetchedProfile])
+              ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValueOnce(new Map([[pointers[0], fetchedProfile]]))
 
               await component.start?.(createStartOptions())
               await jest.advanceTimersByTimeAsync(0)
@@ -499,7 +499,7 @@ describe('ownership validator job', () => {
       beforeEach(async () => {
         pointers = ['0x1234567890123456789012345678901234567890']
         ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValue(pointers)
-        ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValue([])
+        ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValue(new Map())
 
         component = await createOwnershipValidatorJob({
           logs: mockLogs,
@@ -549,7 +549,7 @@ describe('ownership validator job', () => {
       describe('and all profiles are processed', () => {
         beforeEach(async () => {
           ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(pointers)
-          ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValue([])
+          ;(mockCatalyst.getProfiles as jest.Mock).mockResolvedValue(new Map())
 
           await component.start?.(createStartOptions())
           // Allow batch delays to complete
@@ -591,7 +591,7 @@ describe('ownership validator job', () => {
         beforeEach(async () => {
           ;(mockProfilesCache.getAllPointers as jest.Mock).mockReturnValueOnce(pointers)
           ;(mockCatalyst.getProfiles as jest.Mock)
-            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce(new Map())
             .mockRejectedValueOnce(new Error('Batch error'))
 
           await component.start?.(createStartOptions())
@@ -653,7 +653,7 @@ describe('ownership validator job', () => {
           if (batchCount === 2) {
             void component.stop?.()
           }
-          return []
+          return new Map()
         })
 
         component = await createOwnershipValidatorJob({

--- a/test/unit/logic/sync/ownership-validator-job.spec.ts
+++ b/test/unit/logic/sync/ownership-validator-job.spec.ts
@@ -574,7 +574,7 @@ describe('ownership validator job', () => {
               // After first batch, trigger stop (don't await it to avoid deadlock)
               void component.stop?.()
             }
-            return []
+            return new Map()
           })
 
           await component.start?.(createStartOptions())

--- a/test/unit/logic/sync/profile-sanitizer.spec.ts
+++ b/test/unit/logic/sync/profile-sanitizer.spec.ts
@@ -4,13 +4,10 @@ import { createConfigMockComponent } from '../../mocks/config'
 import { createCatalystMockComponent } from '../../mocks/catalyst'
 import { createProfileSanitizerComponent } from '../../../../src/logic/sync/profile-sanitizer'
 import { createAvatar, createAvatarInfo, createProfileEntity } from '../../mocks/data/profiles'
-import { Entity } from '@dcl/schemas'
+import { Entity, Profile } from '@dcl/schemas'
 import { createLogMockComponent } from '../../mocks/logs'
 
 const MOCK_PROFILE_IMAGES_URL = 'https://profiles.mock.org'
-// createProfileEntity's default pointer, which the served identity is pinned to
-const DEFAULT_POINTER = '0x0000000000000000000000000000000000000000'
-const pinnedIdentity = { userId: DEFAULT_POINTER, ethAddress: DEFAULT_POINTER }
 
 describe('profile sanitizer', () => {
   let catalystMock: ICatalystComponent
@@ -48,8 +45,16 @@ describe('profile sanitizer', () => {
         entityIdB = 'bafy'
         pointerA = '0x1111111111111111111111111111111111111111'
         pointerB = '0x2222222222222222222222222222222222222222'
-        entityA = createProfileEntity({ id: entityIdA, pointers: [pointerA] })
-        entityB = createProfileEntity({ id: entityIdB, pointers: [pointerB] })
+        entityA = createProfileEntity({
+          id: entityIdA,
+          pointers: [pointerA],
+          metadata: { avatars: [createAvatar({ userId: pointerA, ethAddress: pointerA })] }
+        })
+        entityB = createProfileEntity({
+          id: entityIdB,
+          pointers: [pointerB],
+          metadata: { avatars: [createAvatar({ userId: pointerB, ethAddress: pointerB })] }
+        })
         profilesToSanitize = [
           { entityId: entityIdA, pointer: pointerA, timestamp: 1 },
           { entityId: entityIdB, pointer: pointerB, timestamp: 2 }
@@ -93,9 +98,14 @@ describe('profile sanitizer', () => {
 
       describe('and a fetched profile points somewhere else than its deployment', () => {
         beforeEach(() => {
-          catalystMock.getEntitiesByIds = jest
-            .fn()
-            .mockResolvedValueOnce([createProfileEntity({ id: entityIdA, pointers: [pointerB] }), entityB])
+          catalystMock.getEntitiesByIds = jest.fn().mockResolvedValueOnce([
+            createProfileEntity({
+              id: entityIdA,
+              pointers: [pointerB],
+              metadata: { avatars: [createAvatar({ userId: pointerB, ethAddress: pointerB })] }
+            }),
+            entityB
+          ])
         })
 
         it('should discard it and keep the consistent one', async () => {
@@ -141,9 +151,14 @@ describe('profile sanitizer', () => {
 
       describe('and a fetched profile has no pointers', () => {
         beforeEach(() => {
-          catalystMock.getEntitiesByIds = jest
-            .fn()
-            .mockResolvedValueOnce([createProfileEntity({ id: entityIdA, pointers: [] }), entityB])
+          catalystMock.getEntitiesByIds = jest.fn().mockResolvedValueOnce([
+            createProfileEntity({
+              id: entityIdA,
+              pointers: [],
+              metadata: { avatars: [createAvatar({ userId: pointerA, ethAddress: pointerA })] }
+            }),
+            entityB
+          ])
         })
 
         it('should discard it', async () => {
@@ -155,15 +170,70 @@ describe('profile sanitizer', () => {
 
       describe('and a fetched profile pointer differs only in casing', () => {
         beforeEach(() => {
-          catalystMock.getEntitiesByIds = jest
-            .fn()
-            .mockResolvedValueOnce([createProfileEntity({ id: entityIdA, pointers: [pointerA.toUpperCase()] })])
+          catalystMock.getEntitiesByIds = jest.fn().mockResolvedValueOnce([
+            createProfileEntity({
+              id: entityIdA,
+              pointers: [pointerA.toUpperCase()],
+              metadata: { avatars: [createAvatar({ userId: pointerA, ethAddress: pointerA })] }
+            })
+          ])
         })
 
         it('should keep it, since pointers are compared normalized', async () => {
           const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
 
           expect(result).toHaveLength(1)
+        })
+      })
+
+      describe('and a fetched avatar carries an address other than the pointer', () => {
+        beforeEach(() => {
+          catalystMock.getEntitiesByIds = jest.fn().mockResolvedValueOnce([
+            createProfileEntity({
+              id: entityIdA,
+              pointers: [pointerA],
+              metadata: {
+                avatars: [createAvatar({ userId: pointerB, ethAddress: pointerB, avatar: createAvatarInfo() })]
+              }
+            })
+          ])
+        })
+
+        it('should settle the ethAddress to the pointer before it is stored', async () => {
+          const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
+
+          expect((result[0].metadata as Profile).avatars[0].ethAddress).toEqual(pointerA)
+        })
+
+        it('should settle the userId to the pointer before it is stored', async () => {
+          const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
+
+          expect((result[0].metadata as Profile).avatars[0].userId).toEqual(pointerA)
+        })
+      })
+
+      describe('and the fetched profile is a default profile', () => {
+        const deployedAddress = '0x3333333333333333333333333333333333333333'
+
+        beforeEach(() => {
+          profilesToSanitize = [{ entityId: entityIdA, pointer: 'default5', timestamp: 1 }]
+          catalystMock.getEntitiesByIds = jest.fn().mockResolvedValueOnce([
+            createProfileEntity({
+              id: entityIdA,
+              pointers: ['default5'],
+              metadata: {
+                avatars: [
+                  createAvatar({ userId: deployedAddress, ethAddress: deployedAddress, avatar: createAvatarInfo() })
+                ]
+              }
+            })
+          ])
+        })
+
+        it('should leave the deployed identity untouched, since its pointer is a name', async () => {
+          const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
+
+          expect((result[0].metadata as Profile).avatars[0].ethAddress).toEqual(deployedAddress)
         })
       })
 
@@ -254,7 +324,6 @@ describe('profile sanitizer', () => {
           avatars: [
             {
               ...avatarA,
-              ...pinnedIdentity,
               avatar: {
                 ...avatarA.avatar,
                 snapshots: {
@@ -270,7 +339,6 @@ describe('profile sanitizer', () => {
           avatars: [
             {
               ...avatarB,
-              ...pinnedIdentity,
               avatar: {
                 ...avatarB.avatar,
                 snapshots: {
@@ -311,69 +379,9 @@ describe('profile sanitizer', () => {
         expect(result).toHaveLength(1)
         expect(result[0]).toEqual({
           timestamp,
-          avatars: [{ ...simpleAvatar, ...pinnedIdentity }]
+          avatars: [simpleAvatar]
         })
         expect(result[0].avatars[0].avatar).toBeUndefined()
-      })
-    })
-
-    describe('when an avatar has a different address than the pointer', () => {
-      let entities: Entity[]
-      let pointer: string
-
-      beforeEach(() => {
-        pointer = '0x1111111111111111111111111111111111111111'
-        entities = [
-          createProfileEntity({
-            id: 'bafz',
-            pointers: [pointer],
-            metadata: {
-              avatars: [
-                createAvatar({
-                  userId: '0x2222222222222222222222222222222222222222',
-                  ethAddress: '0x2222222222222222222222222222222222222222',
-                  avatar: createAvatarInfo()
-                })
-              ]
-            }
-          })
-        ]
-      })
-
-      it('should serve the pointer as the ethAddress', () => {
-        const result = component.mapEntitiesToProfiles(entities)
-
-        expect(result[0].avatars[0].ethAddress).toEqual(pointer)
-      })
-
-      it('should serve the pointer as the userId', () => {
-        const result = component.mapEntitiesToProfiles(entities)
-
-        expect(result[0].avatars[0].userId).toEqual(pointer)
-      })
-    })
-
-    describe('when the pointer is not an address', () => {
-      let entities: Entity[]
-      let deployedAddress: string
-
-      beforeEach(() => {
-        deployedAddress = '0x3333333333333333333333333333333333333333'
-        entities = [
-          createProfileEntity({
-            id: 'bafz',
-            pointers: ['default5'],
-            metadata: {
-              avatars: [createAvatar({ ethAddress: deployedAddress, avatar: createAvatarInfo() })]
-            }
-          })
-        ]
-      })
-
-      it('should leave the deployed ethAddress untouched', () => {
-        const result = component.mapEntitiesToProfiles(entities)
-
-        expect(result[0].avatars[0].ethAddress).toEqual(deployedAddress)
       })
     })
 
@@ -400,7 +408,7 @@ describe('profile sanitizer', () => {
           face256: 'https://profiles.mock.org/entities/bafz/face.png',
           body: 'https://profiles.mock.org/entities/bafz/body.png'
         })
-        expect(result[0].avatars[1]).toEqual({ ...avatarWithoutInfo, ...pinnedIdentity })
+        expect(result[0].avatars[1]).toEqual(avatarWithoutInfo)
         expect(result[0].avatars[1].avatar).toBeUndefined()
       })
     })

--- a/test/unit/logic/sync/profile-sanitizer.spec.ts
+++ b/test/unit/logic/sync/profile-sanitizer.spec.ts
@@ -37,14 +37,22 @@ describe('profile sanitizer', () => {
     describe('when there are profiles to sanitize', () => {
       let entityIdA: string
       let entityIdB: string
+      let pointerA: string
+      let pointerB: string
+      let entityA: Entity
+      let entityB: Entity
       let profilesToSanitize: Sync.ProfileDeployment[]
 
       beforeEach(() => {
         entityIdA = 'bafz'
         entityIdB = 'bafy'
+        pointerA = '0x1111111111111111111111111111111111111111'
+        pointerB = '0x2222222222222222222222222222222222222222'
+        entityA = createProfileEntity({ id: entityIdA, pointers: [pointerA] })
+        entityB = createProfileEntity({ id: entityIdB, pointers: [pointerB] })
         profilesToSanitize = [
-          { entityId: entityIdA, pointer: '0x123', timestamp: 1 },
-          { entityId: entityIdB, pointer: '0x456', timestamp: 2 }
+          { entityId: entityIdA, pointer: pointerA, timestamp: 1 },
+          { entityId: entityIdB, pointer: pointerB, timestamp: 2 }
         ]
       })
 
@@ -68,14 +76,12 @@ describe('profile sanitizer', () => {
 
       describe('and all profiles are found in catalyst', () => {
         beforeEach(async () => {
-          catalystMock.getEntitiesByIds = jest
-            .fn()
-            .mockResolvedValueOnce([createProfileEntity({ id: entityIdA }), createProfileEntity({ id: entityIdB })])
+          catalystMock.getEntitiesByIds = jest.fn().mockResolvedValueOnce([entityA, entityB])
         })
 
         it('should return the profiles', async () => {
           const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
-          expect(result).toEqual([createProfileEntity({ id: entityIdA }), createProfileEntity({ id: entityIdB })])
+          expect(result).toEqual([entityA, entityB])
         })
 
         it('should not call callback', async () => {
@@ -85,14 +91,90 @@ describe('profile sanitizer', () => {
         })
       })
 
+      describe('and a fetched profile points somewhere else than its deployment', () => {
+        beforeEach(() => {
+          catalystMock.getEntitiesByIds = jest
+            .fn()
+            .mockResolvedValueOnce([createProfileEntity({ id: entityIdA, pointers: [pointerB] }), entityB])
+        })
+
+        it('should discard it and keep the consistent one', async () => {
+          const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
+
+          expect(result).toEqual([entityB])
+        })
+      })
+
+      describe('and a fetched profile carries no avatars', () => {
+        beforeEach(() => {
+          catalystMock.getEntitiesByIds = jest
+            .fn()
+            .mockResolvedValueOnce([
+              createProfileEntity({ id: entityIdA, pointers: [pointerA], metadata: {} }),
+              entityB
+            ])
+        })
+
+        it('should discard it so it is never stored or served', async () => {
+          const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
+
+          expect(result).toEqual([entityB])
+        })
+      })
+
+      describe('and a fetched profile carries an empty avatars array', () => {
+        beforeEach(() => {
+          catalystMock.getEntitiesByIds = jest
+            .fn()
+            .mockResolvedValueOnce([
+              createProfileEntity({ id: entityIdA, pointers: [pointerA], metadata: { avatars: [] } }),
+              entityB
+            ])
+        })
+
+        it('should discard it', async () => {
+          const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
+
+          expect(result).toEqual([entityB])
+        })
+      })
+
+      describe('and a fetched profile has no pointers', () => {
+        beforeEach(() => {
+          catalystMock.getEntitiesByIds = jest
+            .fn()
+            .mockResolvedValueOnce([createProfileEntity({ id: entityIdA, pointers: [] }), entityB])
+        })
+
+        it('should discard it', async () => {
+          const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
+
+          expect(result).toEqual([entityB])
+        })
+      })
+
+      describe('and a fetched profile pointer differs only in casing', () => {
+        beforeEach(() => {
+          catalystMock.getEntitiesByIds = jest
+            .fn()
+            .mockResolvedValueOnce([createProfileEntity({ id: entityIdA, pointers: [pointerA.toUpperCase()] })])
+        })
+
+        it('should keep it, since pointers are compared normalized', async () => {
+          const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
+
+          expect(result).toHaveLength(1)
+        })
+      })
+
       describe('and some profiles are not found in catalyst', () => {
         beforeEach(async () => {
-          catalystMock.getEntitiesByIds = jest.fn().mockResolvedValueOnce([createProfileEntity({ id: entityIdA })])
+          catalystMock.getEntitiesByIds = jest.fn().mockResolvedValueOnce([entityA])
         })
 
         it('should return the profiles', async () => {
           const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
-          expect(result).toEqual([createProfileEntity({ id: entityIdA })])
+          expect(result).toEqual([entityA])
         })
 
         it('should call callback with not found profiles', async () => {

--- a/test/unit/logic/sync/profile-sanitizer.spec.ts
+++ b/test/unit/logic/sync/profile-sanitizer.spec.ts
@@ -269,7 +269,7 @@ describe('profile sanitizer', () => {
       })
     })
 
-    describe('when the pointer is a default profile name', () => {
+    describe('when the pointer is not an address', () => {
       let entities: Entity[]
       let deployedAddress: string
 

--- a/test/unit/logic/sync/profile-sanitizer.spec.ts
+++ b/test/unit/logic/sync/profile-sanitizer.spec.ts
@@ -111,12 +111,13 @@ describe('profile sanitizer', () => {
       beforeEach(() => {
         entity = createProfileEntity({
           id: 'bafz',
-          pointers: ['0x123'],
+          pointers: ['default5'],
           metadata: {
             avatars: [
               {
                 hasClaimedName: false,
-                name: 'test'
+                name: 'test',
+                nameColor: { r: 1, g: 2, b: 3 }
               }
             ]
           }
@@ -126,9 +127,10 @@ describe('profile sanitizer', () => {
       it('should return the metadata', () => {
         const result = component.getMetadata(entity)
         expect(result).toEqual({
-          pointer: '0x123',
+          pointer: 'default5',
           hasClaimedName: false,
           name: 'test',
+          nameColor: { r: 1, g: 2, b: 3 },
           thumbnailUrl: 'https://profiles.mock.org/entities/bafz/face.png'
         })
       })

--- a/test/unit/logic/sync/profile-sanitizer.spec.ts
+++ b/test/unit/logic/sync/profile-sanitizer.spec.ts
@@ -8,6 +8,9 @@ import { Entity } from '@dcl/schemas'
 import { createLogMockComponent } from '../../mocks/logs'
 
 const MOCK_PROFILE_IMAGES_URL = 'https://profiles.mock.org'
+// createProfileEntity's default pointer, which the served identity is pinned to
+const DEFAULT_POINTER = '0x0000000000000000000000000000000000000000'
+const pinnedIdentity = { userId: DEFAULT_POINTER, ethAddress: DEFAULT_POINTER }
 
 describe('profile sanitizer', () => {
   let catalystMock: ICatalystComponent
@@ -167,6 +170,7 @@ describe('profile sanitizer', () => {
           avatars: [
             {
               ...avatarA,
+              ...pinnedIdentity,
               avatar: {
                 ...avatarA.avatar,
                 snapshots: {
@@ -182,6 +186,7 @@ describe('profile sanitizer', () => {
           avatars: [
             {
               ...avatarB,
+              ...pinnedIdentity,
               avatar: {
                 ...avatarB.avatar,
                 snapshots: {
@@ -222,9 +227,69 @@ describe('profile sanitizer', () => {
         expect(result).toHaveLength(1)
         expect(result[0]).toEqual({
           timestamp,
-          avatars: [simpleAvatar]
+          avatars: [{ ...simpleAvatar, ...pinnedIdentity }]
         })
         expect(result[0].avatars[0].avatar).toBeUndefined()
+      })
+    })
+
+    describe('when an avatar has a different address than the pointer', () => {
+      let entities: Entity[]
+      let pointer: string
+
+      beforeEach(() => {
+        pointer = '0x1111111111111111111111111111111111111111'
+        entities = [
+          createProfileEntity({
+            id: 'bafz',
+            pointers: [pointer],
+            metadata: {
+              avatars: [
+                createAvatar({
+                  userId: '0x2222222222222222222222222222222222222222',
+                  ethAddress: '0x2222222222222222222222222222222222222222',
+                  avatar: createAvatarInfo()
+                })
+              ]
+            }
+          })
+        ]
+      })
+
+      it('should serve the pointer as the ethAddress', () => {
+        const result = component.mapEntitiesToProfiles(entities)
+
+        expect(result[0].avatars[0].ethAddress).toEqual(pointer)
+      })
+
+      it('should serve the pointer as the userId', () => {
+        const result = component.mapEntitiesToProfiles(entities)
+
+        expect(result[0].avatars[0].userId).toEqual(pointer)
+      })
+    })
+
+    describe('when the pointer is a default profile name', () => {
+      let entities: Entity[]
+      let deployedAddress: string
+
+      beforeEach(() => {
+        deployedAddress = '0x3333333333333333333333333333333333333333'
+        entities = [
+          createProfileEntity({
+            id: 'bafz',
+            pointers: ['default5'],
+            metadata: {
+              avatars: [createAvatar({ ethAddress: deployedAddress, avatar: createAvatarInfo() })]
+            }
+          })
+        ]
+      })
+
+      it('should leave the deployed ethAddress untouched', () => {
+        const result = component.mapEntitiesToProfiles(entities)
+
+        expect(result[0].avatars[0].ethAddress).toEqual(deployedAddress)
       })
     })
 
@@ -251,7 +316,7 @@ describe('profile sanitizer', () => {
           face256: 'https://profiles.mock.org/entities/bafz/face.png',
           body: 'https://profiles.mock.org/entities/bafz/body.png'
         })
-        expect(result[0].avatars[1]).toEqual(avatarWithoutInfo)
+        expect(result[0].avatars[1]).toEqual({ ...avatarWithoutInfo, ...pinnedIdentity })
         expect(result[0].avatars[1].avatar).toBeUndefined()
       })
     })


### PR DESCRIPTION
## Why

An avatar's `userId` and `ethAddress` are metadata copied from the deployment, so they can disagree with the pointer the profile is stored under. Consumers of `/profiles` treat those fields as the address of the profile, so the disagreement was observable to them: unity-explorer and social-service-ea both read profiles from this service and key by them.

Nothing here re-derived either field, and the pointer an entity gets stored under was itself read from the metadata, so a profile could be filed under an address other than the one it was requested for.

## What changed

The served identity now comes from `entity.pointers[0]`, and the storage pointer is never read from metadata:

- `profile-sanitizer` sets `userId` and `ethAddress` from the pointer in the transform that feeds `/profiles`. Default profiles keep their deployed value, since their pointer is a name (`default5`) rather than an address.
- `convertLambdasProfileToEntity` now takes the pointer as an argument instead of reading `avatars[0].ethAddress`, so the entity is always keyed by the pointer it was requested for.
- `catalyst.getProfiles` returns a `Map` keyed by the requested pointer. The lambdas response carries no requested-id echo, so entries are matched on the address in their metadata: only requested pointers are accepted, and an address appearing twice is dropped as ambiguous rather than resolved arbitrarily.
- The ownership validator looks profiles up by pointer instead of by `userId`. A pointer with no matching entry is now logged instead of being skipped silently, which previously meant the profile was never compared against the ownership-sanitised version.

Also fixes a lookup in `profile-retriever` that compared lowercased database pointers against the raw requested strings, so any request using checksummed addresses always fell through to the catalyst layer and re-persisted.

## Tests

- New `test/unit/adapters/catalyst.spec.ts` covers the requested-pointer matching: an address that was not requested is not returned, a duplicated address is dropped, a match is keyed by the requested pointer, and checksummed requests key by the lowercased pointer.
- `profile-sanitizer.spec.ts` covers the pinned identity and the default-profile exemption.
- Existing mocks updated for the new `Map` return type and the extra argument.

`382/382` unit tests pass; typecheck, ESLint and Prettier are clean.

## Related

- decentraland/lamb2 applies the same normalisation to its `/lambdas/profiles` response.
- decentraland/core-libs adds a content-validator rule so new deployments must agree with the pointer.