### PR TITLE
feat: serve default profiles from the catalyst fallback

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -818,10 +818,10 @@ components:
             Profile pointers to fetch. A pointer is either an Ethereum address or, for default
             profiles, a name such as `default5`.
 
-            An address resolves from the cache, the database, or a catalyst lookup. A default profile
-            name resolves from the cache or the database only: a catalyst response reports that
-            profile's deployer address rather than the name, so it cannot be attributed to the name
-            it was asked for.
+            Both resolve from the cache, the database, or a catalyst lookup. Addresses are looked up
+            in one batch, while default profile names are looked up one at a time, since a catalyst
+            response reports that profile's deployer address rather than the name it was asked for.
+            At most 25 default profile names per request for that reason; addresses are not capped.
 
             Empty arrays are accepted and return an empty response.
       required:

--- a/src/adapters/catalyst.ts
+++ b/src/adapters/catalyst.ts
@@ -7,6 +7,7 @@ import { AppComponents, ICatalystComponent, CatalystFetchOptions } from '../type
 import { isAddressPointer, isDefaultProfilePointer } from '../utils/pointers'
 
 const ENTITY_ID_FROM_SNAPSHOT_REGEX = /\/entities\/([^/]+)\//
+const NAME_POINTER_LOOKUP_CONCURRENCY = 5
 
 export async function createCatalystAdapter({
   config,
@@ -38,15 +39,15 @@ export async function createCatalystAdapter({
     return match ? match[1] : null
   }
 
-  function convertLambdasProfileToEntity(profile: Profile): Entity | null {
+  function convertLambdasProfileToEntity(profile: Profile, requestedPointer: string): Entity | null {
     const avatars = profile.avatars ?? []
     const avatar = avatars[0]
 
-    if (!avatar?.ethAddress) {
+    if (!avatar) {
       return null
     }
 
-    const pointer = avatar.ethAddress.toLowerCase()
+    const pointer = requestedPointer.toLowerCase()
 
     const snapshotUrl = avatar.avatar?.snapshots?.body || avatar.avatar?.snapshots?.face256
     if (!snapshotUrl) {
@@ -68,13 +69,12 @@ export async function createCatalystAdapter({
       timestamp: profile.timestamp!,
       content: [],
       // The entity is keyed by this pointer, so the identity it carries is settled to match it: the
-      // node this came from serves it from the pointer, but only from the version that does so
+      // node this came from serves it from the pointer, but only from the version that does so. A
+      // default profile is pointed at by name and keeps the deployer address it was deployed with.
       metadata: {
-        avatars: avatars.map((profileAvatar) => ({
-          ...profileAvatar,
-          userId: pointer,
-          ethAddress: pointer
-        }))
+        avatars: isAddressPointer(pointer)
+          ? avatars.map((profileAvatar) => ({ ...profileAvatar, userId: pointer, ethAddress: pointer }))
+          : avatars
       }
     }
   }
@@ -176,29 +176,15 @@ export async function createCatalystAdapter({
     return contentJson as Entity
   }
 
-  async function getProfiles(pointers: string[]): Promise<Map<string, Profile>> {
-    const profilesByPointer = new Map<string, Profile>()
+  async function getProfilesByAddress(pointers: string[]): Promise<Map<string, Profile>> {
+    const matched = new Map<string, Profile>()
 
-    // A default profile is pointed at by name and reports the deployer's address, so its response
-    // cannot be attributed to the name it was asked for. Only address pointers are looked up here;
-    // names resolve from the cache or the database, where this service syncs those deployments.
-    const addressPointers = pointers.filter(isAddressPointer)
-    const skipped = pointers.filter((pointer) => !isAddressPointer(pointer))
-    const defaultProfiles = skipped.filter(isDefaultProfilePointer).length
-
-    if (skipped.length > 0) {
-      logger.debug('Skipping catalyst lookup for pointers that are not addresses', {
-        defaultProfiles,
-        notAPointer: skipped.length - defaultProfiles
-      })
-    }
-
-    if (addressPointers.length === 0) {
-      return profilesByPointer
+    if (pointers.length === 0) {
+      return matched
     }
 
     try {
-      const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: addressPointers })
+      const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: pointers })
 
       // Lambdas serves an address profile's identity from the entity pointer, so the address it
       // reports is the pointer the profile was requested for
@@ -206,14 +192,93 @@ export async function createCatalystAdapter({
         const address = profile.avatars?.[0]?.ethAddress?.toLowerCase()
 
         if (address) {
-          profilesByPointer.set(address, profile)
+          matched.set(address, profile)
         }
       }
     } catch (error: any) {
       logger.error('Error fetching profiles from historical catalyst lambdas', {
         error: error?.message || 'Unknown error',
-        count: addressPointers.length
+        count: pointers.length
       })
+    }
+
+    return matched
+  }
+
+  async function getProfileByNamePointer(pointer: string): Promise<Profile | null> {
+    try {
+      const profiles = await historicalLambdasClient.getAvatarsDetailsByPost({ ids: [pointer] })
+
+      // Asked for one pointer, so anything other than a single profile cannot be attributed to it
+      if (profiles.length !== 1 || !profiles[0].avatars?.[0]) {
+        return null
+      }
+
+      return profiles[0]
+    } catch (error: any) {
+      logger.error('Error fetching profile from historical catalyst lambdas', {
+        pointer,
+        error: error?.message || 'Unknown error'
+      })
+      return null
+    }
+  }
+
+  async function getProfilesByNamePointers(pointers: string[]): Promise<Map<string, Profile>> {
+    const matched = new Map<string, Profile>()
+
+    // Each costs its own request, so they go out in bounded chunks rather than all at once
+    for (let i = 0; i < pointers.length; i += NAME_POINTER_LOOKUP_CONCURRENCY) {
+      const chunk = pointers.slice(i, i + NAME_POINTER_LOOKUP_CONCURRENCY)
+      const profiles = await Promise.all(chunk.map((pointer) => getProfileByNamePointer(pointer)))
+
+      chunk.forEach((pointer, index) => {
+        const profile = profiles[index]
+
+        if (profile) {
+          matched.set(pointer.toLowerCase(), profile)
+        }
+      })
+    }
+
+    return matched
+  }
+
+  async function getProfiles(pointers: string[]): Promise<Map<string, Profile>> {
+    const profilesByPointer = new Map<string, Profile>()
+
+    // Addresses can be batched, because lambdas reports each one back. Every default profile reports
+    // the same deployer address instead, so those are asked for one at a time to know which name
+    // each answer belongs to. Anything else cannot match a profile and is not looked up at all.
+    const addressPointers: string[] = []
+    const namePointers: string[] = []
+    let ignored = 0
+
+    for (const pointer of pointers) {
+      if (isAddressPointer(pointer)) {
+        addressPointers.push(pointer)
+      } else if (isDefaultProfilePointer(pointer)) {
+        namePointers.push(pointer)
+      } else {
+        ignored++
+      }
+    }
+
+    if (ignored > 0) {
+      logger.debug('Ignored pointers that are neither an address nor a default profile name', { ignored })
+    }
+
+    if (addressPointers.length === 0 && namePointers.length === 0) {
+      return profilesByPointer
+    }
+
+    const [byAddress, byName] = await Promise.all([
+      getProfilesByAddress(addressPointers),
+      getProfilesByNamePointers(namePointers)
+    ])
+
+    for (const [pointer, profile] of [...byAddress, ...byName]) {
+      profilesByPointer.set(pointer, profile)
     }
 
     return profilesByPointer

--- a/src/controllers/schemas/profiles.ts
+++ b/src/controllers/schemas/profiles.ts
@@ -1,10 +1,15 @@
 import { InvalidRequestError } from '@dcl/http-commons'
+import { isDefaultProfilePointer } from '../../utils/pointers'
+
+export const MAX_NAME_POINTERS_PER_REQUEST = 25
 
 /**
  * Validates the shape of the body of the profile endpoints, so a malformed one is reported as a bad
- * request instead of failing further down. The amount of ids is deliberately not capped: callers
- * batch whole pages of friends or community members, and the lookups behind this are one upstream
- * request regardless of how many are asked for.
+ * request instead of failing further down.
+ *
+ * The amount of addresses is deliberately not capped: callers batch whole pages of friends or
+ * community members, and those resolve through a single upstream request however many are asked for.
+ * Default profile names are capped, because each one costs its own request.
  */
 function getIds(body: unknown): unknown {
   if (typeof body !== 'object' || body === null || !('ids' in body)) {
@@ -23,6 +28,14 @@ export function parseProfilePointers(body: unknown): string[] {
 
   if (!isNonEmptyStringArray(pointers)) {
     throw new InvalidRequestError('The ids property must be an array of non-empty strings')
+  }
+
+  const namePointers = pointers.filter(isDefaultProfilePointer)
+
+  if (namePointers.length > MAX_NAME_POINTERS_PER_REQUEST) {
+    throw new InvalidRequestError(
+      `A maximum of ${MAX_NAME_POINTERS_PER_REQUEST} default profile ids can be requested at once, got ${namePointers.length}`
+    )
   }
 
   return pointers

--- a/src/logic/profile-retriever.ts
+++ b/src/logic/profile-retriever.ts
@@ -58,8 +58,8 @@ export function createProfileRetrieverComponent(
       const profilesByPointer = await catalyst.getProfiles(pointers)
       const entities: Entity[] = []
 
-      for (const profile of profilesByPointer.values()) {
-        const entity = catalyst.convertLambdasProfileToEntity(profile)
+      for (const [pointer, profile] of profilesByPointer) {
+        const entity = catalyst.convertLambdasProfileToEntity(profile, pointer)
         if (entity) {
           entities.push(entity)
         }

--- a/src/logic/sync/ownership-validator-job.ts
+++ b/src/logic/sync/ownership-validator-job.ts
@@ -114,7 +114,7 @@ export async function createOwnershipValidatorJob(
       if (originalProfile && shouldUpdateProfile(originalProfile, sanitizedProfile)) {
         logger.info('Profile update required', { pointer })
 
-        const curatedProfile = catalyst.convertLambdasProfileToEntity(sanitizedProfile)
+        const curatedProfile = catalyst.convertLambdasProfileToEntity(sanitizedProfile, pointer)
 
         if (!curatedProfile) {
           logger.error('Failed to convert sanitized profile to entity', { pointer })

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -202,7 +202,7 @@ export interface ICatalystComponent {
   getEntityByPointers(pointers: string[]): Promise<Entity[]>
   getContent(id: string): Promise<Entity | undefined>
   getProfiles(pointers: string[]): Promise<Map<string, Profile>>
-  convertLambdasProfileToEntity(profile: Profile): Entity | null
+  convertLambdasProfileToEntity(profile: Profile, requestedPointer: string): Entity | null
 }
 
 export interface IWorldsComponent {

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -31,6 +31,32 @@ function createLambdasProfile(address: string, timestamp = 1000): Profile {
   } as unknown as Profile
 }
 
+// The shape lambdas serves a default profile in: identity is the deployer address it was deployed
+// with, checksummed, and there is no userId at all
+function createLambdasDefaultProfile(): Profile {
+  return {
+    timestamp: 1000,
+    avatars: [
+      {
+        name: '',
+        description: '',
+        version: 1,
+        tutorialStep: 1,
+        hasClaimedName: false,
+        ethAddress: '0x1337e0507EB4aB47E08a179573ED4533d9E22a7b',
+        avatar: {
+          bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseFemale',
+          wearables: ['urn:decentraland:off-chain:base-avatars:curly_hair'],
+          snapshots: {
+            body: 'https://profile-images.decentraland.org/entities/bafkreidefault/body.png',
+            face256: 'https://profile-images.decentraland.org/entities/bafkreidefault/face.png'
+          }
+        }
+      }
+    ]
+  } as unknown as Profile
+}
+
 describe('catalyst adapter', () => {
   const requestedPointer = '0x1111111111111111111111111111111111111111'
   let component: ICatalystComponent
@@ -187,6 +213,28 @@ describe('catalyst adapter', () => {
         const entity = component.convertLambdasProfileToEntity(createLambdasProfile(deployerAddress), 'default5')
 
         expect((entity?.metadata as Profile).avatars?.[0].ethAddress).toEqual(deployerAddress)
+      })
+
+      it('should carry the avatars through exactly as lambdas serves them', () => {
+        const profile = createLambdasDefaultProfile()
+
+        const entity = component.convertLambdasProfileToEntity(profile, 'default5')
+
+        expect((entity?.metadata as Profile).avatars).toEqual(profile.avatars)
+      })
+
+      it('should not introduce a userId that lambdas does not report', () => {
+        const entity = component.convertLambdasProfileToEntity(createLambdasDefaultProfile(), 'default5')
+
+        expect((entity?.metadata as Profile).avatars?.[0]).not.toHaveProperty('userId')
+      })
+
+      it('should keep the checksummed casing of the deployed address', () => {
+        const entity = component.convertLambdasProfileToEntity(createLambdasDefaultProfile(), 'default5')
+
+        expect((entity?.metadata as Profile).avatars?.[0].ethAddress).toEqual(
+          '0x1337e0507EB4aB47E08a179573ED4533d9E22a7b'
+        )
       })
     })
 

--- a/test/unit/adapters/catalyst.spec.ts
+++ b/test/unit/adapters/catalyst.spec.ts
@@ -61,27 +61,65 @@ describe('catalyst adapter', () => {
     })
 
     describe('and a default profile name is requested', () => {
+      const deployerAddress = '0x1337000000000000000000000000000000001337'
+
       beforeEach(() => {
         // A default profile reports the deployer address, not the name it was asked for
-        getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile('0x1337000000000000000000000000000000001337')])
+        getAvatarsDetailsByPost.mockResolvedValue([createLambdasProfile(deployerAddress)])
       })
 
-      it('should not look it up, since the response could not be attributed to it', async () => {
-        await component.getProfiles(['default5'])
+      it('should key it by the name it was asked for', async () => {
+        const result = await component.getProfiles(['default5'])
 
-        expect(getAvatarsDetailsByPost).not.toHaveBeenCalled()
+        expect(result.get('default5')).toBeDefined()
       })
 
-      it('should not return a profile under the address it would have reported', async () => {
+      it('should not key it by the deployer address it reports', async () => {
+        const result = await component.getProfiles(['default5'])
+
+        expect(result.has(deployerAddress)).toBe(false)
+      })
+
+      it('should ask for it on its own, which is what attributes the answer to the name', async () => {
+        await component.getProfiles(['default5', requestedPointer])
+
+        expect(getAvatarsDetailsByPost).toHaveBeenCalledWith({ ids: ['default5'] })
+        expect(getAvatarsDetailsByPost).toHaveBeenCalledWith({ ids: [requestedPointer] })
+      })
+
+      it('should look every requested name up rather than truncate', async () => {
+        const names = Array.from({ length: 12 }, (_, index) => `default${index}`)
+
+        await component.getProfiles(names)
+
+        expect(getAvatarsDetailsByPost).toHaveBeenCalledTimes(names.length)
+      })
+    })
+
+    describe('and a name pointer answer holds more than one profile', () => {
+      beforeEach(() => {
+        getAvatarsDetailsByPost.mockResolvedValue([
+          createLambdasProfile('0x1337000000000000000000000000000000001337'),
+          createLambdasProfile(requestedPointer)
+        ])
+      })
+
+      it('should drop it rather than guess which name it belongs to', async () => {
         const result = await component.getProfiles(['default5'])
 
         expect(result.size).toEqual(0)
       })
+    })
 
-      it('should still look up the address pointers requested alongside it', async () => {
-        await component.getProfiles(['default5', requestedPointer])
+    describe('and an id is neither an address nor a default profile name', () => {
+      beforeEach(() => {
+        getAvatarsDetailsByPost.mockResolvedValue([])
+      })
 
-        expect(getAvatarsDetailsByPost).toHaveBeenCalledWith({ ids: [requestedPointer] })
+      it('should not look it up at all', async () => {
+        await component.getProfiles(['not-a-pointer'])
+
+        expect(getAvatarsDetailsByPost).not.toHaveBeenCalled()
       })
     })
 
@@ -109,7 +147,7 @@ describe('catalyst adapter', () => {
       })
 
       it('should settle the userId to the pointer the entity is keyed by', () => {
-        const entity = component.convertLambdasProfileToEntity(profile)
+        const entity = component.convertLambdasProfileToEntity(profile, requestedPointer)
 
         expect((entity?.metadata as Profile).avatars?.[0].userId).toEqual(requestedPointer)
       })
@@ -119,7 +157,10 @@ describe('catalyst adapter', () => {
       let entity: ReturnType<ICatalystComponent['convertLambdasProfileToEntity']>
 
       beforeEach(() => {
-        entity = component.convertLambdasProfileToEntity(createLambdasProfile(requestedPointer.toUpperCase()))
+        entity = component.convertLambdasProfileToEntity(
+          createLambdasProfile(requestedPointer.toUpperCase()),
+          requestedPointer.toUpperCase()
+        )
       })
 
       it('should key the entity by the lowercased pointer', () => {
@@ -133,8 +174,24 @@ describe('catalyst adapter', () => {
       })
     })
 
+    describe('and the pointer is a default profile name', () => {
+      const deployerAddress = '0x1337000000000000000000000000000000001337'
+
+      it('should key the entity by the name', () => {
+        const entity = component.convertLambdasProfileToEntity(createLambdasProfile(deployerAddress), 'default5')
+
+        expect(entity?.pointers).toEqual(['default5'])
+      })
+
+      it('should leave the deployed identity alone, since the pointer is not an address', () => {
+        const entity = component.convertLambdasProfileToEntity(createLambdasProfile(deployerAddress), 'default5')
+
+        expect((entity?.metadata as Profile).avatars?.[0].ethAddress).toEqual(deployerAddress)
+      })
+    })
+
     it('should point the entity at the address it reports', () => {
-      const entity = component.convertLambdasProfileToEntity(createLambdasProfile(requestedPointer))
+      const entity = component.convertLambdasProfileToEntity(createLambdasProfile(requestedPointer), requestedPointer)
 
       expect(entity?.pointers).toEqual([requestedPointer])
     })

--- a/test/unit/controllers/schemas/profiles.spec.ts
+++ b/test/unit/controllers/schemas/profiles.spec.ts
@@ -1,5 +1,5 @@
 import { InvalidRequestError } from '@dcl/http-commons'
-import { parseProfilePointers } from '../../../../src/controllers/schemas/profiles'
+import { MAX_NAME_POINTERS_PER_REQUEST, parseProfilePointers } from '../../../../src/controllers/schemas/profiles'
 
 describe('profile pointers request schema', () => {
   describe('when the body holds an array of pointers', () => {
@@ -47,6 +47,32 @@ describe('profile pointers request schema', () => {
         'default1',
         'default2'
       ]
+    })
+
+    it('should return them, since only the names are limited', () => {
+      expect(parseProfilePointers({ ids })).toHaveLength(ids.length)
+    })
+  })
+
+  describe('when more default profile names than their limit are requested', () => {
+    let ids: string[]
+
+    beforeEach(() => {
+      ids = Array.from({ length: MAX_NAME_POINTERS_PER_REQUEST + 1 }, (_, index) => `default${index}`)
+    })
+
+    it('should throw an invalid request error naming the limit', () => {
+      expect(() => parseProfilePointers({ ids })).toThrow(
+        `A maximum of ${MAX_NAME_POINTERS_PER_REQUEST} default profile ids can be requested at once, got ${ids.length}`
+      )
+    })
+  })
+
+  describe('when many addresses are requested alongside a few default profile names', () => {
+    let ids: string[]
+
+    beforeEach(() => {
+      ids = [...Array.from({ length: 600 }, (_, index) => `0x${index.toString().padStart(40, '0')}`), 'default1']
     })
 
     it('should return them, since only the names are limited', () => {

--- a/test/unit/logic/sync/profile-sanitizer.spec.ts
+++ b/test/unit/logic/sync/profile-sanitizer.spec.ts
@@ -235,6 +235,21 @@ describe('profile sanitizer', () => {
 
           expect((result[0].metadata as Profile).avatars[0].ethAddress).toEqual(deployedAddress)
         })
+
+        it('should not introduce a userId when the deployment does not carry one', async () => {
+          catalystMock.getEntitiesByIds = jest.fn().mockResolvedValueOnce([
+            createProfileEntity({
+              id: entityIdA,
+              pointers: ['default5'],
+              // lambdas serves a default profile without a userId, so neither may this
+              metadata: { avatars: [{ name: '', hasClaimedName: false, ethAddress: deployedAddress }] }
+            })
+          ])
+
+          const result = await component.sanitizeProfiles(profilesToSanitize, jest.fn())
+
+          expect((result[0].metadata as Profile).avatars[0]).not.toHaveProperty('userId')
+        })
       })
 
       describe('and some profiles are not found in catalyst', () => {


### PR DESCRIPTION
Follow-up to #130, which shipped the identity work. This closes one gap it left open.

## Why

`/profiles` accepts a default profile pointer such as `default5`, but after #130 one that misses the cache and the database resolves to nothing: names are excluded from the catalyst lookup. This makes the endpoint behave the same for both pointer forms.

Worth being precise about what `main` did before #130, because it looks like this used to work and only half of it did. It sent the name to lambdas and returned the answer, so a caller did receive the profile — but `convertLambdasProfileToEntity` keyed the entity by the `ethAddress` the answer reported, which for a default profile is the deployer's address. The row therefore landed on **that account's** pointer and shadowed its real profile, and no `default5` row was ever created: the next request missed again and rewrote the deployer's row again. #130 stopped that by not asking for names at all. This restores the answer and keys it correctly.

## How

Lambdas reports every default profile under the same deployer address, and response order is not part of the contract, so a batched answer cannot be attributed to the names requested. Each name is asked for on its own, where the single answer is unambiguously the one requested.

On where this sits relative to the trust boundary agreed on #130: a per-name request is how we know *which question was answered*, not a check on the answer. Nothing inspects or second-guesses what lambdas returns.

- `getProfiles` batches addresses as before and looks names up one at a time, keyed by the requested name.
- `convertLambdasProfileToEntity` takes the pointer to key the entity by, since a name cannot be derived from the answer. It settles identity only when that pointer is an address, so a default profile keeps the deployer address it carries — matching ingestion and the rows the migration produces.
- Name lookups run in chunks of 5, and the request schema caps them at 25 per request since each costs a request. Addresses stay uncapped and resolve in one batch.

## Tests

- a requested name is keyed by the name, not by the deployer address it reports
- it is asked for on its own when mixed with an address, and every requested name is looked up rather than truncated
- an answer holding more than one profile is dropped rather than guessed at
- an id that is neither an address nor a default name is not looked up at all
- converting with a name pointer keys the entity by the name and leaves the deployed identity alone
- the name cap is enforced, and addresses alongside names are unaffected by it

`408/408` unit tests, typecheck, Prettier and ESLint clean.

## Note

No consumer requests default profiles from this service today — the auth flow reads them from the content server, and unity-explorer generates a random profile locally when one is missing — so this is completeness rather than a live fix. It removes the asymmetry in an endpoint that accepts both pointer forms.